### PR TITLE
Korrektur einzelne frage

### DIFF
--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -54,7 +54,14 @@
                        (domain/freitext-fragen)
                        (domain/sortierte-antworten-von-freitext-fragen db/antworten-von-frage)
                        (domain/antworten-korrigiert (db/korrekturen-von-korrektorin-korrigiert user-id))
-                       (domain/timestamp-to-datum-and-uhrzeit)))))
+                       (domain/timestamp-to-datum-and-uhrzeit))))
+           (GET "/antwort-fuer-korrektur/:aid" [aid]
+             (response
+               (->> (db/antworten-fuer-korrektur aid)
+                    (domain/antworten-fuer-korrektur-ansicht)
+                    (domain/korrekturen-into-antwort db/korrekturen-von-antwort))))
+           (POST "/korrektur-fuer-antwort/:aid" [aid]
+             (println "Neue Korrektur für Antwort" aid)))
   (GET "/api/access-token" request (str (extract-token request)))
   (GET "/api/session" request (str (:session request)))
   (route/not-found "Not Found"))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -60,8 +60,11 @@
                (->> (db/antworten-fuer-korrektur aid)
                     (domain/antworten-fuer-korrektur-ansicht)
                     (domain/korrekturen-into-antwort db/korrekturen-von-antwort))))
-           (POST "/korrektur-fuer-antwort/:aid" [aid]
-             (println "Neue Korrektur für Antwort" aid)))
+           (POST "/korrektur-fuer-antwort/:aid" [aid :as r]
+             (let [korrektur (:body-params r)]
+               (response
+                 (->> (domain/check-incoming-korrektur korrektur (db/antworten-fuer-korrektur aid))
+                      (domain/add-korrektur-if-no-error db/korrektor-add-korrektur aid))))))
   (GET "/api/access-token" request (str (extract-token request)))
   (GET "/api/session" request (str (:session request)))
   (route/not-found "Not Found"))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -56,15 +56,15 @@
                        (domain/antworten-korrigiert (db/korrekturen-von-korrektorin-korrigiert user-id))
                        (domain/timestamp-to-datum-and-uhrzeit))))
            (GET "/antwort-fuer-korrektur/:aid" [aid]
-             (response
-               (->> (db/antworten-fuer-korrektur aid)
-                    (domain/antworten-fuer-korrektur-ansicht)
-                    (domain/korrekturen-into-antwort db/korrekturen-von-antwort))))
+                (response
+                  (->> (db/antworten-fuer-korrektur aid)
+                       (domain/antworten-fuer-korrektur-ansicht)
+                       (domain/korrekturen-into-antwort db/korrekturen-von-antwort))))
            (POST "/korrektur-fuer-antwort/:aid" [aid :as r]
-             (let [korrektur (:body-params r)]
-               (response
-                 (->> (domain/check-incoming-korrektur korrektur (db/antworten-fuer-korrektur aid))
-                      (domain/add-korrektur-if-no-error db/korrektor-add-korrektur aid))))))
+                 (let [korrektur (:body-params r)]
+                   (response
+                     (->> (domain/check-incoming-korrektur korrektur (db/antworten-fuer-korrektur aid))
+                          (domain/add-korrektur-if-no-error db/korrektor-add-korrektur aid))))))
   (GET "/api/access-token" request (str (extract-token request)))
   (GET "/api/session" request (str (:session request)))
   (route/not-found "Not Found"))

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -194,7 +194,7 @@
   (mapv first
         (d/q '[:find (pull ?antwort [:antwort/id
                                      :antwort/punkte
-                                     :antwort/antwort-text
+                                     :antwort/antwort
                                      {:antwort/frage [:frage/frage-text :frage/punkte :frage/loesungskriterien]}])
                :in $ ?antwort
                :where
@@ -216,6 +216,20 @@
            [?tx :db/txInstant ?timestamp]
            [?korrektur :korrektur/korrektur-text ?korr-text]]
          @conn antwort-id)))
+
+
+(defn korrektor-add-korrektur
+  [ant-id {text :korrektur/korrektur-text punkte :korrektur/punkte korr-id :korrektor/id}]
+  (let [tx-result (d/transact conn
+                              [{:db/id -1
+                                :korrektur/korrektur-text text
+                                :korrektur/korrektor [:user/id korr-id]
+                                :korrektur/antwort [:antwort/id ant-id]}
+                               {:antwort/id ant-id
+                                :antwort/punkte punkte}])
+        db-after (:db-after tx-result)
+        ids (:tempids tx-result)]
+    (d/pull db-after [:korrektur/korrektur-text {:korrektur/antwort [:antwort/punkte]}] (get ids -1))))
 
 
 (comment 

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -195,8 +195,7 @@
         (d/q '[:find (pull ?antwort [:antwort/id
                                      :antwort/punkte
                                      :antwort/antwort-text
-                                     {:antwort/frage [:frage/frage-text :frage/punkte :frage/loesung]}
-                                     {:antwort/user [:user/id]}])
+                                     {:antwort/frage [:frage/frage-text :frage/punkte :frage/loesungskriterien]}])
                :in $ ?antwort
                :where
                [?antwort :antwort/frage ?frage]

--- a/src/clj/db/dummy_data.clj
+++ b/src/clj/db/dummy_data.clj
@@ -29,7 +29,7 @@
     :frage/choices #{"Lasagne" "Eis" "Schnecken" "Pasta"}
     :frage/multiple-choice-loesung #{"Lasagne" "Eis" "Pasta"}
     :frage/punkte 1}
-   {:frage/id "3"
+   {:frage/id "6"
     :frage/frage-text "Nächste Frage gefällig?"
     :frage/typ :frage.typ/text
     :frage/loesungskriterien "Lösung"
@@ -42,7 +42,7 @@
     :test/fragen [[:frage/id "1"] [:frage/id "3"] [:frage/id "4"] [:frage/id "5"]]}
    {:test/id "2"
     :test/name "Test 2"
-    :test/fragen [[:frage/id "1"]]}])
+    :test/fragen [[:frage/id "1"] [:frage/id "6"]]}])
 
 
 (def faecher

--- a/src/clj/domain.clj
+++ b/src/clj/domain.clj
@@ -115,13 +115,12 @@
         korrekturen-sorted (reverse (sort-by :korrektur/timestamp korrekturen))]
     (if (first korrekturen-sorted)
       (merge antwort (first korrekturen-sorted))
-      (assoc antwort :korrektur/id nil))))
+      antwort)))
 
 
 (defn antworten-fuer-korrektur-ansicht
   [[antwort-map]]
   (let [antwort-unpacked-frage-nested (merge antwort-map (:antwort/frage antwort-map))
-        antwort-unpacked-nested (merge antwort-unpacked-frage-nested (:antwort/user antwort-unpacked-frage-nested))
-        antwort-unpacked (select-keys antwort-unpacked-nested [:user/id :frage/frage-text :frage/punkte :frage/loesung
-                                                               :antwort/antwort-text :antwort/punkte :antwort/id])]
+        antwort-unpacked (select-keys antwort-unpacked-frage-nested [:user/id :frage/frage-text :frage/punkte :frage/loesung
+                                                                     :antwort/antwort-text :antwort/punkte :antwort/id])]
     antwort-unpacked))

--- a/src/clj/domain.clj
+++ b/src/clj/domain.clj
@@ -120,7 +120,33 @@
 
 (defn antworten-fuer-korrektur-ansicht
   [[antwort-map]]
-  (let [antwort-unpacked-frage-nested (merge antwort-map (:antwort/frage antwort-map))
+  (let [antwort-unpacked-frage-nested (update (merge antwort-map (:antwort/frage antwort-map)) :antwort/antwort first)
         antwort-unpacked (select-keys antwort-unpacked-frage-nested [:user/id :frage/frage-text :frage/punkte :frage/loesung
-                                                                     :antwort/antwort-text :antwort/punkte :antwort/id])]
+                                                                     :antwort/antwort :antwort/punkte :antwort/id])]
     antwort-unpacked))
+
+
+(defn check-incoming-korrektur
+  [korrektur passende-antwort]
+  (if-not (first passende-antwort)
+    (assoc korrektur :error :keine-passende-antwort)
+    (let [frage-punkte (get-in (first passende-antwort) [:antwort/frage :frage/punkte])]
+      (cond
+        (not frage-punkte)
+        (assoc korrektur :error :keine-passende-antwort)
+        (or (not (:korrektur/korrektur-text korrektur)) (empty? (:korrektur/korrektur-text korrektur)))
+        (assoc korrektur :error :korrektur-text-missing)
+        (or (not (:korrektur/punkte korrektur)) (empty? (:korrektur/punkte korrektur)))
+        (assoc korrektur :error :korrektur-punkte-missing)
+        (not (nat-int? (read-string (:korrektur/punkte korrektur))))
+        (assoc korrektur :error :punkte-invalid)
+        (> (read-string (:korrektur/punkte korrektur)) frage-punkte)
+        (assoc korrektur :error :punkte-zu-viel)
+        :else (update korrektur :korrektur/punkte read-string)))))
+
+
+(defn add-korrektur-if-no-error
+  [add-korrektur-fct ant-id korrektur]
+  (if (:error korrektur)
+    korrektur
+    (add-korrektur-fct ant-id korrektur)))

--- a/src/clj/domain.clj
+++ b/src/clj/domain.clj
@@ -107,3 +107,21 @@
         antworten-ohne-studi (map #(dissoc % :user/id) antworten-mit-korrekturen)
         antwort-ids-for-this-korrektor (into #{} (map :antwort/id antworten))]
     (filter #(contains? antwort-ids-for-this-korrektor (:antwort/id %)) antworten-ohne-studi)))
+
+
+(defn korrekturen-into-antwort
+  [korrekturen-von-antwort antwort]
+  (let [korrekturen (korrekturen-von-antwort (:antwort/id antwort))
+        korrekturen-sorted (reverse (sort-by :korrektur/timestamp korrekturen))]
+    (if (first korrekturen-sorted)
+      (merge antwort (first korrekturen-sorted))
+      (assoc antwort :korrektur/id nil))))
+
+
+(defn antworten-fuer-korrektur-ansicht
+  [[antwort-map]]
+  (let [antwort-unpacked-frage-nested (merge antwort-map (:antwort/frage antwort-map))
+        antwort-unpacked-nested (merge antwort-unpacked-frage-nested (:antwort/user antwort-unpacked-frage-nested))
+        antwort-unpacked (select-keys antwort-unpacked-nested [:user/id :frage/frage-text :frage/punkte :frage/loesung
+                                                               :antwort/antwort-text :antwort/punkte :antwort/id])]
+    antwort-unpacked))

--- a/src/clj/domain/spec.clj
+++ b/src/clj/domain/spec.clj
@@ -68,7 +68,7 @@
 
 
 (s/def ::antwort
-  (s/keys :req [:antwort/user :antwort/antwort-text :antwort/frage]))
+  (s/keys :req [:antwort/user :antwort/antwort :antwort/frage]))
 
 
 (s/def :korrektur/korrektor ::user)

--- a/src/cljs/events.cljs
+++ b/src/cljs/events.cljs
@@ -12,8 +12,8 @@
   :init-db
   (fn [db _]
     (assoc db
-           :user {:id 0 :name "Test_User"}
-           :korrektor {:id 1 :name "Test_Korrektor"})))
+           :user {:id "0" :name "Test_User"}
+           :korrektor {:id "1" :name "Test_Korrektor"})))
 
 
 ;; Default event for HTTP Failure

--- a/src/cljs/korrektur/events.cljs
+++ b/src/cljs/korrektur/events.cljs
@@ -1,0 +1,61 @@
+(ns korrektur.events
+  (:require
+    [ajax.core :as ajax]
+    [re-frame.core :as rf]
+    [vars]))
+
+
+(rf/reg-event-fx
+  :korrektur/laden
+  (fn [{:keys [db]} [_ antwort-id]]
+    {:db          (assoc db :loading true)
+     :http-xhrio  {:method          :get
+                   :uri             (str vars/base-url "/antwort-fuer-korrektur/" antwort-id)
+                   :timeout         8000
+                   :response-format (ajax/transit-response-format)
+                   :on-success      [:korrektur/angekommen]}}))
+
+
+(rf/reg-event-db
+  :korrektur/angekommen
+  (fn [db [_ test]]
+    (-> db
+        (assoc :loading false)
+        (assoc :korrektur test))))
+
+
+(rf/reg-event-db
+  :korrektur/entfernen
+  (fn [db _]
+    (dissoc db :korrektur)))
+
+
+(rf/reg-event-db
+  :korrektur/schreiben
+  (fn [db [_ korrektur-text]]
+    (assoc-in db [:korrektur :korrektur/korrektur-text] korrektur-text)))
+
+
+(rf/reg-event-db
+  :korrektur/punkte
+  (fn [db [_ korrektur-punkte]]
+    (assoc-in db [:korrektur :korrektur/punkte] korrektur-punkte)))
+
+
+(rf/reg-event-fx
+  :korrektur/senden
+  (fn [{:keys [db]} _]
+    (let [antwort-id (get-in db [:korrektur :antwort/id])
+          korrektur (select-keys (:korrektur db) [:antwort/id :korrektur/korrektur-text :korrektur/punkte])]
+      {:http-xhrio  {:method          :post
+                     :uri             (str vars/base-url "/korrektur-fuer-antwort/" antwort-id)
+                     :params          korrektur
+                     :format          (ajax/transit-request-format)
+                     :response-format (ajax/transit-response-format)
+                     :on-success      [:korrektur/erfolgreich-gesendet]}})))
+
+
+(rf/reg-event-db
+  :korrektur/erfolgreich-gesendet
+  (fn [db _]
+    (assoc-in db [:korrektur :gesendet] true)))

--- a/src/cljs/korrektur/subs.cljs
+++ b/src/cljs/korrektur/subs.cljs
@@ -1,0 +1,8 @@
+(ns korrektur.subs
+  (:require
+    [re-frame.core :as rf]))
+
+
+(rf/reg-sub
+  :korrektur/erhalten
+  (fn [db _] (:korrektur db)))

--- a/src/cljs/korrektur/views.cljs
+++ b/src/cljs/korrektur/views.cljs
@@ -18,7 +18,7 @@
 
 
 (defn korrektur-form
-  [{ant-punkte :antwort/punkte frag-punkte :frage/punkte :as m}]
+  [{frag-punkte :frage/punkte :as m}]
   [:div
    [:p "Korrekturtext: "
     [:input
@@ -28,7 +28,7 @@
    [:p "Punkte: "
     [:input
      {:type "number"
-      :value (get m :korrektur/punkte ant-punkte)
+      :value (get m :korrektur/punkte 0)
       :on-change #(rf/dispatch [:korrektur/punkte (-> % .-target .-value)])}]
     (str " von " frag-punkte)]
    [:p
@@ -41,7 +41,7 @@
   [gesendet]
   ;; Add more precise error handling
   (if gesendet
-    [:p {:style {:color "green"}} "Korrektur abgesendet"]
+    [:p {:style {:color "green"}} (str "Korrektur abgesendet " gesendet)]
     [:p]))
 
 
@@ -53,7 +53,7 @@
      [:p (str "Lösungsvorschlag: ")]
      [:p (:frage/loesungskriterien korrektur)]
      [:p (str "Antwort:")]
-     [:p (:antwort/antwort-text korrektur)]
+     [:p (:antwort/antwort korrektur)]
      [korrektur-form korrektur]
      [korrektur-erfolgreich (:gesendet korrektur)]]))
 

--- a/src/cljs/korrektur/views.cljs
+++ b/src/cljs/korrektur/views.cljs
@@ -1,0 +1,66 @@
+(ns korrektur.views
+  (:require
+    [korrektur.events]
+    [korrektur.subs]
+    [re-frame.core :as rf]))
+
+
+(defn headline
+  []
+  (let [user @(rf/subscribe [:korrektor])]
+    [:div
+     [:p (str "Logged in as: " user)
+      [:input
+       {:type  "button"
+        :value "Logout"
+        ;; :on-click #(rf/dispatch [:logout])
+        }]]]))
+
+
+<<<<<<< HEAD
+(defn korrektur-form
+  [{ant-punkte :antwort/punkte frag-punkte :frage/punkte :as m}]
+  [:div
+   [:p "Korrekturtext: "
+    [:input
+     {:type  "text"
+      :value (get m :korrektur/korrektur-text "Korrekturtext")
+      :on-change #(rf/dispatch [:korrektur/schreiben (-> % .-target .-value)])}]]
+   [:p "Punkte: "
+    [:input
+     {:type "number"
+      :value (get m :korrektur/punkte ant-punkte)
+      :on-change #(rf/dispatch [:korrektur/punkte (-> % .-target .-value)])}]
+    (str " von " frag-punkte)]
+   [:p
+    [:input {:type  "button"
+             :value "Korrigieren"
+             :on-click #(rf/dispatch [:korrektur/senden])}]]])
+
+
+(defn korrektur-erfolgreich
+  [gesendet]
+  ;; Add more precise error handling
+  (if gesendet
+    [:p {:style {:color "green"}} "Korrektur abgesendet"]
+    [:p]))
+
+
+(defn show-antwort-to-korrigieren
+  []
+  (let [korrektur @(rf/subscribe [:korrektur/erhalten])]
+    [:div
+     [:h2 (str (:frage/frage-text korrektur) " - " (:frage/punkte korrektur) " Punkte")]
+     [:p (str "Lösungsvorschlag: ")]
+     [:p (:frage/loesung korrektur)]
+     [:p (str "Antwort von " (:user/id korrektur) ":")]
+     [:p (:antwort/antwort-text korrektur)]
+     [korrektur-form korrektur]
+     [korrektur-erfolgreich (:gesendet korrektur)]]))
+
+
+(defn overview
+  []
+  [:div
+   [headline]
+   [show-antwort-to-korrigieren]])

--- a/src/cljs/korrektur/views.cljs
+++ b/src/cljs/korrektur/views.cljs
@@ -17,7 +17,6 @@
         }]]]))
 
 
-<<<<<<< HEAD
 (defn korrektur-form
   [{ant-punkte :antwort/punkte frag-punkte :frage/punkte :as m}]
   [:div
@@ -52,8 +51,8 @@
     [:div
      [:h2 (str (:frage/frage-text korrektur) " - " (:frage/punkte korrektur) " Punkte")]
      [:p (str "Lösungsvorschlag: ")]
-     [:p (:frage/loesung korrektur)]
-     [:p (str "Antwort von " (:user/id korrektur) ":")]
+     [:p (:frage/loesungskriterien korrektur)]
+     [:p (str "Antwort:")]
      [:p (:antwort/antwort-text korrektur)]
      [korrektur-form korrektur]
      [korrektur-erfolgreich (:gesendet korrektur)]]))

--- a/src/cljs/korrektur_uebersicht/views.cljs
+++ b/src/cljs/korrektur_uebersicht/views.cljs
@@ -36,7 +36,7 @@
   [:p
    [:input
     {:type  "button"
-     :value (str test-name ", beantwortet um " uhrzeit ", " datum " (" fachtitel ", " semester ", " jahr ")")
+     :value (str test-name ", beantwortet um " uhrzeit ", " datum " (" fachtitel ", " semester ", " jahr ", Antwort-Id " antwort-id ")")
      :on-click #(rf/dispatch [:router/push-state {:name :router/korrektur
                                                   :path-params {:aid antwort-id}}])}]])
 

--- a/src/cljs/korrektur_uebersicht/views.cljs
+++ b/src/cljs/korrektur_uebersicht/views.cljs
@@ -31,14 +31,14 @@
 
 
 (defn show-antwort
-  [{_antwort-id :antwort/id test-name :test/name datum :antwort/datum uhrzeit :antwort/uhrzeit fachtitel :fach/fachtitel
+  [{antwort-id :antwort/id test-name :test/name datum :antwort/datum uhrzeit :antwort/uhrzeit fachtitel :fach/fachtitel
     semester :kurs/semester jahr :kurs/jahr}]
   [:p
    [:input
     {:type  "button"
      :value (str test-name ", beantwortet um " uhrzeit ", " datum " (" fachtitel ", " semester ", " jahr ")")
-     ;; :on-click #(rf/dispatch [])
-     }]])
+     :on-click #(rf/dispatch [:router/push-state {:name :router/korrektur
+                                                  :path-params {:aid antwort-id}}])}]])
 
 
 (defn show-antworten

--- a/src/cljs/router.cljs
+++ b/src/cljs/router.cljs
@@ -1,7 +1,11 @@
 (ns router
   (:require
     [korrektur-uebersicht.views :as korr]
+<<<<<<< HEAD
     [orga.frage-erstellen.views :as frage-erstln]
+=======
+    [korrektur.views :as korrektur]
+>>>>>>> Feat: No framework for korrektur
     [re-frame.core :as re-frame]
     [reitit.coercion.spec :as rss]
     [reitit.core :as r]
@@ -87,7 +91,18 @@
      :link-text "Neue Frage erstellen"
      :controllers
      [{:start #(re-frame/dispatch [:frage-erstellen/init])
-       :stop  #(re-frame/dispatch [:frage-erstellen/entfernen])}]}]])
+       :stop  #(re-frame/dispatch [:frage-erstellen/entfernen])}]}]
+   ["antwort-fuer-korrektur/:aid"
+    {:name      ::korrektur
+     :view      korrektur/overview
+     :link-text "Korrektur"
+     :parameters {:path {:aid int?}}
+     :controllers
+     [{:parameters {:path [:aid]}
+       :start (fn [params]
+                (re-frame/dispatch [:korrektur/laden (get-in params [:path :aid])]))
+       :stop (fn [_]
+               (re-frame/dispatch [:korrektur/entfernen]))}]}]])
 
 
 (defn on-navigate

--- a/src/cljs/router.cljs
+++ b/src/cljs/router.cljs
@@ -1,11 +1,8 @@
 (ns router
   (:require
     [korrektur-uebersicht.views :as korr]
-<<<<<<< HEAD
-    [orga.frage-erstellen.views :as frage-erstln]
-=======
     [korrektur.views :as korrektur]
->>>>>>> Feat: No framework for korrektur
+    [orga.frage-erstellen.views :as frage-erstln]
     [re-frame.core :as re-frame]
     [reitit.coercion.spec :as rss]
     [reitit.core :as r]

--- a/src/cljs/studierenden_uebersicht/events.cljs
+++ b/src/cljs/studierenden_uebersicht/events.cljs
@@ -13,8 +13,7 @@
                    :uri             (str vars/base-url "/user/" (get-in db [:user :id]) "/kurse")
                    :timeout         8000
                    :response-format (ajax/transit-response-format)
-                   :on-success      [:kurse/angekommen]
-                   :with-credentials true}}))
+                   :on-success      [:kurse/angekommen]}}))
 
 
 (rf/reg-event-db

--- a/src/cljs/studierenden_uebersicht/views.cljs
+++ b/src/cljs/studierenden_uebersicht/views.cljs
@@ -32,8 +32,7 @@
 
 
 (defn show-kurs
-  [{_id :kurs/id
-    jahr :kurs/jahr
+  [{jahr :kurs/jahr
     semester :kurs/semester
     fach :kurs/fach
     tests :kurs/tests}]

--- a/src/cljs/test/events.cljs
+++ b/src/cljs/test/events.cljs
@@ -13,8 +13,7 @@
                    :uri             (str vars/base-url "/test/" test-id)
                    :timeout         8000
                    :response-format (ajax/transit-response-format)
-                   :on-success      [:test/angekommen]
-                   :with-credentials true}}))
+                   :on-success      [:test/angekommen]}}))
 
 
 (rf/reg-event-db
@@ -59,8 +58,7 @@
                      :params          antworten
                      :format          (ajax/transit-request-format)
                      :response-format (ajax/transit-response-format)
-                     :on-success      [:antworten/erfolgreich-gesendet]
-                     :with-credentials true}})))
+                     :on-success      [:antworten/erfolgreich-gesendet]}})))
 
 
 (rf/reg-event-db

--- a/test/domain_test.clj
+++ b/test/domain_test.clj
@@ -217,3 +217,35 @@
           antworten [{:antwort/id "0"}, {:antwort/id "1"}, {:antwort/id "2"}]
           result [{:antwort/id "0"}, {:antwort/id "1"}, {:antwort/id "2"}]]
       (t/is (= result (d/antworten-korrigiert korrigierte-antworten antworten))))))
+
+
+(t/deftest test-antworten-fuer-korrektur-ansicht
+  (t/testing "Eine Antwort aufbereiten"
+    (let [input [{:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5,
+                  :antwort/frage {:frage/frage-text "Fragetext", :frage/punkte 6, :frage/loesungskriterien "Loesung"}
+                  :antwort/user {:user/id 1}}]
+          output {:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
+                  :frage/punkte 6, :frage/loesungskriterien "Loesung", :user/id 1}]
+      (t/is output (d/antworten-fuer-korrektur-ansicht input)))))
+
+
+(t/deftest test-korrekturen-into-antwort
+  (t/testing "Keine Korrektur vorhanden"
+    (let [antwort {:antwort/id 0}
+          korrekturen-fct (fn [_id] [])
+          result (merge antwort {:korrektur/id nil})]
+      (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort))))
+  (t/testing "Eine Korrektur vorhanden"
+    (let [antwort {:antwort/id 0}
+          korrektur {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
+          korrekturen-fct (fn [_id] (conj [] korrektur))
+          result (merge antwort korrektur)]
+      (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort))))
+  (t/testing "Mehrere Korrekturen vorhanden"
+    (let [antwort {:antwort/id 0}
+          korrekturen-fct (fn [_id]
+                            [{:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-03")}
+                             {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
+                             {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-04")}])
+          result (merge antwort {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")})]
+      (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort)))))

--- a/test/domain_test.clj
+++ b/test/domain_test.clj
@@ -221,32 +221,32 @@
 
 (t/deftest test-antworten-fuer-korrektur-ansicht
   (t/testing "Eine Antwort aufbereiten"
-    (let [input [{:antwort/id 0, :antwort/antwort ["Antwort"], :antwort/punkte 5,
+    (let [input [{:antwort/id "0", :antwort/antwort ["Antwort"], :antwort/punkte 5,
                   :antwort/frage {:frage/frage-text "Fragetext", :frage/punkte 6, :frage/loesungskriterien "Loesung"}}]
-          output {:antwort/id 0, :antwort/antwort "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
+          output {:antwort/id "0", :antwort/antwort "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
                   :frage/punkte 6, :frage/loesungskriterien "Loesung"}]
       (t/is output (d/antworten-fuer-korrektur-ansicht input)))))
 
 
 (t/deftest test-korrekturen-into-antwort
   (t/testing "Keine Korrektur vorhanden"
-    (let [antwort {:antwort/id 0}
+    (let [antwort {:antwort/id "0"}
           korrekturen-fct (fn [_id] [])
           result (merge antwort {:korrektur/id nil})]
       (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort))))
   (t/testing "Eine Korrektur vorhanden"
-    (let [antwort {:antwort/id 0}
-          korrektur {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
+    (let [antwort {:antwort/id "0"}
+          korrektur {:korrektur/id "0" :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
           korrekturen-fct (fn [_id] (conj [] korrektur))
           result (merge antwort korrektur)]
       (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort))))
   (t/testing "Mehrere Korrekturen vorhanden"
-    (let [antwort {:antwort/id 0}
+    (let [antwort {:antwort/id "0"}
           korrekturen-fct (fn [_id]
-                            [{:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-03")}
-                             {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
-                             {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-04")}])
-          result (merge antwort {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")})]
+                            [{:korrektur/id "0" :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-03")}
+                             {:korrektur/id "0" :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")}
+                             {:korrektur/id "0" :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-04")}])
+          result (merge antwort {:korrektur/id "0" :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")})]
       (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort)))))
 
 

--- a/test/domain_test.clj
+++ b/test/domain_test.clj
@@ -222,10 +222,9 @@
 (t/deftest test-antworten-fuer-korrektur-ansicht
   (t/testing "Eine Antwort aufbereiten"
     (let [input [{:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5,
-                  :antwort/frage {:frage/frage-text "Fragetext", :frage/punkte 6, :frage/loesungskriterien "Loesung"}
-                  :antwort/user {:user/id 1}}]
+                  :antwort/frage {:frage/frage-text "Fragetext", :frage/punkte 6, :frage/loesungskriterien "Loesung"}}]
           output {:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
-                  :frage/punkte 6, :frage/loesungskriterien "Loesung", :user/id 1}]
+                  :frage/punkte 6, :frage/loesungskriterien "Loesung"}]
       (t/is output (d/antworten-fuer-korrektur-ansicht input)))))
 
 

--- a/test/domain_test.clj
+++ b/test/domain_test.clj
@@ -221,9 +221,9 @@
 
 (t/deftest test-antworten-fuer-korrektur-ansicht
   (t/testing "Eine Antwort aufbereiten"
-    (let [input [{:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5,
+    (let [input [{:antwort/id 0, :antwort/antwort ["Antwort"], :antwort/punkte 5,
                   :antwort/frage {:frage/frage-text "Fragetext", :frage/punkte 6, :frage/loesungskriterien "Loesung"}}]
-          output {:antwort/id 0, :antwort/antwort-text "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
+          output {:antwort/id 0, :antwort/antwort "Antwort", :antwort/punkte 5, :frage/frage-text "Fragetext",
                   :frage/punkte 6, :frage/loesungskriterien "Loesung"}]
       (t/is output (d/antworten-fuer-korrektur-ansicht input)))))
 
@@ -248,3 +248,65 @@
                              {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-04")}])
           result (merge antwort {:korrektur/id 0 :korrektur/timestamp (.parse (SimpleDateFormat. "yyyy-MM-dd") "2022-08-05")})]
       (t/is result (d/korrekturen-into-antwort korrekturen-fct antwort)))))
+
+
+(t/deftest test-check-incoming-korrektur
+  (t/testing "Input is fine"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "3" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result {:korrektur/korrektur-text "Gut!" :korrektur/punkte 3 :korrektor/id "1"}]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Keine Antwort"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "3" :korrektor/id "1"}
+          antwort-input []
+          result (merge korrektur-input {:error :keine-passende-antwort})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Corrupted Antwort"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "3" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {}}]
+          result (merge korrektur-input {:error :keine-passende-antwort})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Keine Korrektur 1"
+    (let [korrektur-input {:korrektur/punkte "3" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :korrektur-text-missing})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Keine Korrektur 2"
+    (let [korrektur-input {:korrektur/korrektur-text "" :korrektur/punkte "3" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :korrektur-text-missing})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Keine Punkte 1"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!", :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :korrektur-punkte-missing})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Keine Punkte 2"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :korrektur-punkte-missing})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Punkte invalid 1"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "hallo" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :punkte-invalid})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Punkte invalid 2"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "-10" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :punkte-invalid})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input))))
+  (t/testing "Zu viele Punkte"
+    (let [korrektur-input {:korrektur/korrektur-text "Gut!" :korrektur/punkte "10" :korrektor/id "1"}
+          antwort-input [{:antwort/id "0" :antwort/punkte 0 :antwort/antwort "So ist das"
+                          :antwort/frage {:frage/frage-text "Frage" :frage/punkte 4 :frage/loesungskriterien "Kriterien"}}]
+          result (merge korrektur-input {:error :punkte-zu-viel})]
+      (t/is result (d/check-incoming-korrektur korrektur-input antwort-input)))))


### PR DESCRIPTION
Korrektorys können jetzt auf ihre und auf unbeantwortete Textaufgaben zugreifen und sie korrigieren. Das Backend überprüft die Korrektur und lässt sie nicht zu, wenn sie ungültig ist (bsp. negative Punktzahl, zu hohe Punktzahl). 
Die Logik des Korrigierens funktioniert inklusive Einpflegen in die Datenbank. Allerdings klappt das aktuell nicht, da die :post requests noch nicht mit OAuth funktionieren. Das ist aber nicht etwas, was in diesem Branch gelöst werden wird.