### PR TITLE
ring was not configured to run behind a reverse proxy in production

### DIFF
--- a/build.md
+++ b/build.md
@@ -3,8 +3,14 @@ The app can be built to an uber-jar (a jar file containg the app and it's depend
 
 The magic happens in the build.clj file using [clojure/tools.build](https://clojure.org/guides/tools_build).
 
+Note that the App expects to be run behind a reverse proxy that handles TLS termination. All "http" requests are automatically 301 redirected to "https" as configured with `secure-site-defaults`.
 
 ## Shipping a container
 A Dockerfile is provided that builds the uber jar within Docker in an empheral "builder" container and then packs it into a container with .
 
 Voila: We have a build system ready to run in docker and a contanerized version of our app.
+
+## Secrets
+For continous deployment to fly.io, you need to provide your FLY_API_TOKEN to Githubs CI as a repository secret. See the [documentation from fly here](https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/).
+
+As noted in `authentification.md`, you need to provide OAUTH credentials to the application as environment variables. On fly.io, these should be setup as [runtime secrets](https://fly.io/docs/reference/secrets/).

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -7,7 +7,7 @@
     [domain]
     [hiccup2.core :as h]
     [ring.adapter.jetty :refer [run-jetty]]
-    [ring.middleware.defaults :refer [site-defaults wrap-defaults]]
+    [ring.middleware.defaults :refer [site-defaults secure-site-defaults wrap-defaults]]
     [ring.middleware.reload :refer [wrap-reload]]
     [ring.util.response :refer [header response]]))
 
@@ -41,7 +41,7 @@
 
 
 ;; in production, the app will be running behind a reverse proxy that does TLS
-(def app-proxied (-> combined-routes (wrap-defaults (-> site-defaults (assoc-in [:session :cookie-attrs :same-site] :lax)))))
+(def app-proxied (-> combined-routes (wrap-defaults (-> secure-site-defaults (assoc-in [:session :cookie-attrs :same-site] :lax) (assoc :proxy true)))))
 
 (def app-dev (wrap-reload #'app))
 


### PR DESCRIPTION
To serve our application with transport layer security (https) in production, a reverse proxy is used that handles the TLS-termination (translation the incoming https requests from the internet into plain http requests and handing them to the application).

To have the github oauth `callback_uri` set it's scheme to https and not http, we need to tell ring about this fact. This PR solves this by using the secure-site-defaults from ring.