### PR TITLE
Value for runtime variables were required on build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN clj -T:build clean
 
 COPY Makefile /tmp/
 COPY src /tmp/src
-RUN OAUTH_CLIENT_ID=abc OAUTH_CLIENT_SECRET=xyz make uber
+RUN make uber
 
 FROM amazoncorretto:11.0.19
 COPY --from=builder /tmp/target/expert-parakeet-standalone.jar /app.jar

--- a/src/clj/auth.clj
+++ b/src/clj/auth.clj
@@ -37,8 +37,9 @@
 ;; - kann unsicher sein: andere Prozesse könnten diese auslesen
 ;; - besser: secret als Datei
 ;; - Kubernetes z.B. kann secrets direkt als Datei in den Pod mounten
-(def oauth-client-id (System/getenv "OAUTH_CLIENT_ID"))
-(def oauth-client-secret (System/getenv "OAUTH_CLIENT_SECRET"))
+(def oauth-client-id (if *compile-files* "" (System/getenv "OAUTH_CLIENT_ID")))
+(def oauth-client-secret (if *compile-files* "" (System/getenv "OAUTH_CLIENT_SECRET")))
+
 (assert oauth-client-id "OAUTH_CLIENT_ID is not set")
 (assert oauth-client-secret "OAUTH_CLIENT_SECRET is not set")
 


### PR DESCRIPTION
This fixes the cause by setting the values to an empty string on build time.