### PR TITLE
fixed: No Database writes possible

### DIFF
--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -259,7 +259,7 @@
   (add-course!
     [this course-name]
     (let [id (generate-id this :course/id)
-          tx-result (d/transact @(.conn this)
+          tx-result (d/transact (.conn this)
                                 [{:db/id -1
                                   :course/id id
                                   :course/course-name course-name}])
@@ -282,7 +282,7 @@
     (let [id (generate-id this :course-iteration/id)
           question-set-ids-keyed (mapv (fn [question-set-id] [:question-set/id (str question-set-id)])
                                        question-set-ids)
-          tx-result (d/transact @(.conn this)
+          tx-result (d/transact (.conn this)
                                 [{:db/id     -1
                                   :course-iteration/id   id
                                   :course-iteration/course [:course/id course-id]
@@ -329,7 +329,7 @@
                                  (= type :question.type/multiple-choice)
                                  [:question/possible-solutions (:question/possible-solutions question)
                                   :question/multiple-choice-solution (:question/multiple-choice-solution question)]))
-          tx-result (d/transact @(.conn this) [trans-map])
+          tx-result (d/transact (.conn this) [trans-map])
           db-after (:db-after tx-result)]
       (d/pull db-after  [:question/id :question/question-statement :question/points :question/type :question/possible-solutions
                          :question/evaluation-criteria :question/single-choice-solution
@@ -345,7 +345,7 @@
                                        (:question/id question)
                                        (:question/id (add-question! this question)))) ; frage war noch nicht in db
                                    questions))
-          tx-result-question-set (d/transact @(.conn this)
+          tx-result-question-set (d/transact (.conn this)
                                              [{:db/id                      -1
                                                :question-set/id            id
                                                :question-set/name          question-set-name
@@ -366,7 +366,7 @@
   (add-user-answer!
     [this user-id question-id answer]
     (let [id (generate-id this :answer/id)
-          tx-result (d/transact @(.conn this)
+          tx-result (d/transact (.conn this)
                                 [{:db/id -1
                                   :answer/id id
                                   :answer/question [:question/id question-id]
@@ -422,7 +422,7 @@
 
   (add-correction!
     [this ant-id {feedback :correction/feedback points :correction/points corr-id :corrector/id}]
-    (let [tx-result (d/transact @(.conn this)
+    (let [tx-result (d/transact (.conn this)
                                 [{:db/id -1
                                   :correction/feedback feedback
                                   :correction/corrector [:user/id corr-id]


### PR DESCRIPTION
The query function of datahike expects a dereference connection while the transact function expects the atom of the connection. Fixed the transact calls to use the atom instead of the dereferenced conn.

Effected were the following functions of the Database-Protocol implementation:
* add-course! 
* add-course-iteration-with-question-sets!
* add-question!
* add-question-set!
* add-user-answer!
* add-correction!

I used the following query to test that they work as intended now.
```clj
(db/add-course! db {})
(db/add-course-iteration-with-question-sets! db "1" 2022 "SoSe" [])
(db/add-question! db {:question/points 5
                      :question/question-statement "Hello"
                      :question/evaluation-criteria "hello"
                      :question/type :question.type/free-text})
(db/add-question-set! db "naem" "1" 1 [] 1 2)
(db/add-user-answer! db "1" "1" "no answer")
(db/add-correction! db 1 {})
```
The functions sometimes don't put valid values into the database, but they throw a schema error instead of the following error: 
"Execution error (AssertionError) at datahike.connector/transact! (connector.cljc:65).
Assert failed: (d/conn? connection)"