### PR TITLE
115 fix the create course iteration controller

### DIFF
--- a/src/clj/controllers/course_iteration/course_iteration_controller.clj
+++ b/src/clj/controllers/course_iteration/course_iteration_controller.clj
@@ -91,7 +91,7 @@
 (s/fdef submit-create-course-iteration!
         :args (s/cat :request ::request-data
                      :redirect-uri string?
-                     :db-add-fun (s/? (s/get-spec `db/add-course-iteration-with-question-sets!)))
+                     :course-iteration-service #(satisfies? PCourseIterationService %))
         :ret #(instance? hiccup.util.RawString %))
 
 

--- a/src/clj/controllers/course_iteration/course_iteration_controller.clj
+++ b/src/clj/controllers/course_iteration/course_iteration_controller.clj
@@ -49,11 +49,9 @@
    When the request passed to this function inside of `req` contains predefined error values in the `:query-params` of the `req` parameter, 
    they are displayed as errors within the form.
    The fields can be seen in `view/course-iteration-form`."
-  [req post-destination db & {:keys [get-courses-fun get-question-sets-fun]
-                              :or {get-courses-fun db/get-all-courses
-                                   get-question-sets-fun db/get-all-question-sets}}]
-  (let [courses (get-courses-fun db)
-        question-sets (get-question-sets-fun db)]
+  [req post-destination get-courses-fun get-question-sets-fun]
+  (let [courses (get-courses-fun)
+        question-sets (get-question-sets-fun)]
     (if (empty? courses)
       view/no-courses
       (let [errors (extract-errors req)]

--- a/src/clj/controllers/course_iteration/course_iteration_controller.clj
+++ b/src/clj/controllers/course_iteration/course_iteration_controller.clj
@@ -24,7 +24,6 @@
 (s/fdef create-course-iteration-get
         :args (s/cat :req coll?
                      :post-destination :general/non-blank-string
-                     :db #(satisfies? db/Database-Protocol %)
                      :get-courses-fun (s/? (s/get-spec `db/get-all-courses))
                      :get-question-sets-fun (s/? (s/get-spec `db/get-all-question-sets)))
         :ret #(instance? hiccup.util.RawString %)

--- a/src/clj/controllers/course_iteration/course_iteration_controller.clj
+++ b/src/clj/controllers/course_iteration/course_iteration_controller.clj
@@ -5,7 +5,8 @@
     [db]
     [ring.util.codec :refer [form-encode]]
     [ring.util.response :as response]
-    [services.course-iteration-service.p-course-iteration-service :refer [create-course-iteration validate-course-iteration]]
+    [services.course-iteration-service.p-course-iteration-service :refer [create-course-iteration PCourseIterationService
+                                                                          validate-course-iteration]]
     [util.ring-extensions :refer [html-response]]
     [util.spec-functions :refer [map-spec]]
     [views.course-iteration.create-course-iteration-view :as view]))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -42,8 +42,8 @@
 
   (GET "/create-course-iteration" req
        (html-response (create-course-iteration-get req "/create-course-iteration"
-                                                   :get-courses-fun (partial get-all-courses (:course-service services))
-                                                   :get-question-sets-fun (partial get-all-question-sets (:question-set-service services)))))
+                                                   (partial get-all-courses (:course-service services))
+                                                   (partial get-all-question-sets (:question-set-service services)))))
   (POST "/create-course-iteration" req
         (submit-create-course-iteration! req "/create-course-iteration" (:course-iteration-service services)))
   (route/not-found "Not Found"))

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -213,8 +213,8 @@
 
   (get-all-question-sets
     [this]
-    (mapv first (d/q '[:find ?id
-                       :where [_ :question-set/id ?id]]
+    (mapv first (d/q '[:find (pull ?e [:question-set/id :question-set/name])
+                       :where [?e :question-set/id]]
                      @(.conn this))))
 
 

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -220,13 +220,10 @@
 
   (get-all-courses
     [this]
-    (mapv first (d/q '[:find (pull ?e [:course-iteration/id {:course-iteration/course [:course/id :course/course-name]}
-                                       :course-iteration/year
-                                       :course-iteration/semester
-                                       :course-iteration/year
-                                       {:course-iteration/question-sets [:question-set/id]}])
-                       :where [?e :course-iteration/id]]
-                     @(.conn this))))
+    (mapv first
+          (d/q '[:find (pull ?e [:course/id :course/course-name {:course/question-sets [:question-set/id :question-set/name]}])
+                 :where [?e :course/id]]
+               @(.conn this))))
 
 
   (get-course-iterations-of-course


### PR DESCRIPTION
# Task
Needed to remove the dependency on the global db instance which the create-course-iteration-controller still had.

## Changes

* create-course-iteration-controller
  * Removed the default values for the parameters as this resulted in the dependency on the db
  * Updated the specs
  * Updated the tests
* db
  * when fetching course-iterations the names needed to be fetched as well
  * the db was fetching course-iterations when it should be fetching courses
