### PR TITLE
Fixing resource delivery from uber-jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN clj -T:build clean
 # Without that, each change to any file would trigger a redownload of all dependencies.
 
 COPY Makefile /tmp/
-COPY resources/public /tmp/resources/public
+COPY resources /tmp/resources
 COPY src /tmp/src
 RUN make uber
 

--- a/build.clj
+++ b/build.clj
@@ -5,7 +5,6 @@
 
 (def lib 'pkoerner/expert-parakeet)
 (def class-dir "target/classes")
-(def resources-dir "target/classes/resources")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/expert-parakeet.jar"))
 (def uber-file (format "target/expert-parakeet-standalone.jar"))
@@ -22,10 +21,8 @@
                 :lib lib
                 :basis basis
                 :src-dirs ["src"]})
-  (b/copy-dir {:src-dirs ["src"]
+  (b/copy-dir {:src-dirs ["src" "resources"]
                :target-dir class-dir})
-  (b/copy-dir {:src-dirs ["resources"]
-               :target-dir resources-dir})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
 
@@ -33,10 +30,8 @@
 (defn uber
   [_]
   (clean nil)
-  (b/copy-dir {:src-dirs ["src"]
+  (b/copy-dir {:src-dirs ["src" "resources"]
                :target-dir class-dir})
-  (b/copy-dir {:src-dirs ["resources"]
-               :target-dir resources-dir})
   (b/compile-clj {:basis basis
                   :src-dirs ["src"]
                   :class-dir class-dir})

--- a/build.clj
+++ b/build.clj
@@ -5,6 +5,7 @@
 
 (def lib 'pkoerner/expert-parakeet)
 (def class-dir "target/classes")
+(def resources-dir "target/classes/resources")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/expert-parakeet.jar"))
 (def uber-file (format "target/expert-parakeet-standalone.jar"))
@@ -21,8 +22,10 @@
                 :lib lib
                 :basis basis
                 :src-dirs ["src"]})
-  (b/copy-dir {:src-dirs ["src" "resources"]
+  (b/copy-dir {:src-dirs ["src"]
                :target-dir class-dir})
+  (b/copy-dir {:src-dirs ["resources"]
+               :target-dir resources-dir})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
 
@@ -30,8 +33,10 @@
 (defn uber
   [_]
   (clean nil)
-  (b/copy-dir {:src-dirs ["src" "resources"]
+  (b/copy-dir {:src-dirs ["src"]
                :target-dir class-dir})
+  (b/copy-dir {:src-dirs ["resources"]
+               :target-dir resources-dir})
   (b/compile-clj {:basis basis
                   :src-dirs ["src"]
                   :class-dir class-dir})

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths   ["src/clj"]
+{:paths   ["src/clj" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}
            io.replikativ/datahike {:mvn/version "0.5.1507"}
            provisdom/spectomic {:mvn/version "1.0.78"}

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -12,8 +12,8 @@
     [ring.adapter.jetty :refer [run-jetty]]
     [ring.middleware.defaults :refer [secure-site-defaults
                                       site-defaults wrap-defaults]]
-    [ring.middleware.file :refer [wrap-file]]
     [ring.middleware.reload :refer [wrap-reload]]
+    [ring.middleware.resource :refer [wrap-resource]]
     [services.course-iteration-service.course-iteration-service :refer [->CourseIterationService]]
     [services.course-service.course-service :refer [->CourseService]]
     [services.course-service.p-course-service :refer [get-all-courses]]
@@ -70,7 +70,7 @@
 ;; oauth2 middleware callback requires cookie setting :same-site to be lax, see: https://github.com/weavejester/ring-oauth2
 (def app
   (-> combined-routes
-      (wrap-file "resources/public") ; serving of static resources
+      (wrap-resource "public") ; serving of static resources
       (wrap-defaults (-> site-defaults (assoc-in [:session :cookie-attrs :same-site] :lax)))))
 
 


### PR DESCRIPTION
This uses `ring.middleware.resource` instead of `ring.middleware.files`. Please refer to #123 for rationale.