### PR TITLE
118 create proper login process

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           alias: :lint
       - name: run tests
+        env:
+          OAUTH_CLIENT_ID: ''
+          OAUTH_CLIENT_SECRET: ''
         uses: vouch-opensource/tools.deps-build@1.0.1
         with:
           alias: :test-runner

--- a/src/clj/auth.clj
+++ b/src/clj/auth.clj
@@ -20,24 +20,24 @@
 ;; │          │◀─ (F) ───Protected Resource───│    Server     │
 ;; └──────────┘                               └───────────────┘
 
-;; Schritte für den Login:                                    ⎞
-;; - Nutzer wird auf Github weitergeleitet und gefragt,       ⎟
-;;   ob die E-Mail Adresse und andere Dinge für den           ⎟
-;;   Service geteilt werden darf.                             ⎟ Wird von der OAuth2-
-;; - Der Resource Owner wird gefragt,                         ⎟ Middleware gehandhabt
-;;   ob die E-Mail Adresse freigegeben werden darf.           ⎟
-;; - Es gibt einen Grant, mit dem vom Authorization Server    ⎟
-;;   ein Access Token erstellt werden kann                    ⎠
-;; - Wir fragen mit dem Access Token dem Github "Resource Server", ⎞
-;;   was die user-id, e-mail Adresse, Name usw. ist.               ⎟ Eigene Magie
-;; - Wir schreiben diese in die Session                            ⎠
-;; - (optional) Wir können die Session persistent machen (Achtung!)
+;; Authentication Step:                                       ⎞
+;; - User is redirect to GitHub where they are asked          ⎟ Is done by the OAuth2-
+;;   to give our app permission to access their               ⎟ Middleware
+;;   user id.                                                 ⎟ 
+;; - We acquire a 'Authorization Gran' with which we          ⎟
+;;   are able to get an 'Access Token'                        ⎠
+;; - With this 'Access Token' we can make calls to the             ⎞
+;;   GitHub User API and fetch the user-id                         ⎟ Our Magic
+;; - We add the user id to the session                             ⎠
+;; - (optional) Wir could persits the session, currently the session is deleted when the user closes their browser (Attention!)
 
-;; Secrets aus den Umgebungsvariablen
-;; - werden oft in Docker-files als Umgebungsvariable angegeben
-;; - kann unsicher sein: andere Prozesse könnten diese auslesen
-;; - besser: secret als Datei
-;; - Kubernetes z.B. kann secrets direkt als Datei in den Pod mounten
+;; Secrets from Environment variables
+;; - it is important to keep the OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET variables secret!
+;; - For local development this can be handled with normal environment variables in your operating system
+;;   (see our readme.md: https://github.com/pkoerner/expert-parakeet#how-to-run)
+;; - In production we handle this with fly.io runtime secrets and GitHub repository secrets.
+;; - Further information can be found in our readme.md in the
+;;   'Continous Deployment' section (https://github.com/pkoerner/expert-parakeet#continous-deployment)
 (def oauth-client-id (if *compile-files* "" (System/getenv "OAUTH_CLIENT_ID")))
 (def oauth-client-secret (if *compile-files* "" (System/getenv "OAUTH_CLIENT_SECRET")))
 
@@ -49,22 +49,21 @@
 ;; 
 (def oauth-github-profile
   {:github
-   {;; "Resource Owner" -> gibt uns einen Grant
+   {;; "Resource Owner" -> gives us an 'Authorization Grant', meaning we're allowed to user the users account in this authentication process.
     :authorize-uri    "https://github.com/login/oauth/authorize"
-    ;; "Authorization Server" -> gibt uns ein Token
+    ;; "Authorization Server" -> gives us a token to request the account data from the user we previously got a 'Authorization Grant' for.
     :access-token-uri "https://github.com/login/oauth/access_token"
     :client-id        oauth-client-id
     :client-secret    oauth-client-secret
     ;; withouth any scopes definition, github provides us with the uid of the current user, which is all we need.
     ;; :scopes           []
-    ;; Start URL (die muss der Nutzer aufrufen)
-    ;; -> initiiert alles und leitet den Nutzer an Github weiter
+    ;; Start URL
+    ;; -> initiates the oauth process and redirects the user to GitHub 
     :launch-uri       "/oauth2/github"
-    ;; URL, an die Github uns weiter leitet -> im Query String liegt das Token
+    ;; URL where the user will be redirected from GitHub to us -> the query String contains the token
     :redirect-uri     "/oauth2/github/callback"
-    ;; Die middleware leitet uns dort hin weiter, wenn alles geklappt hat
-    ;; -> in dem Handler können wir Github nach der user-id fragen,
-    ;;    die Matr.Nr. in der DB abfragen und alles in die Session speichern
+    ;; The middleware redirects the user to this URL when the oauth was successful.
+    ;; At this point we can process the user id provided by GitHub, e.g. put it in the session.
     :landing-uri      "/oauth2/github/callback-success"}})
 
 
@@ -74,7 +73,7 @@
       (get-in [:oauth2/access-tokens :github :token])))
 
 
-;; API Call zu der Github API
+;; API Call to the Github User API
 (defn github-user-data-from-token
   [token]
   (-> (client/get
@@ -86,8 +85,8 @@
       (select-keys [:id])))
 
 
-;; Github ID zur Session hinzufügen
 (defn- authenticate-session
+  "This function adds the ID provided by the GitHub OAuth to our session."
   [request]
   (let [github-data (github-user-data-from-token (extract-token request))
         oauth-github-id (github-data :id)]
@@ -95,9 +94,6 @@
     {:status 307
      :headers {"Content-Type" "text/plain", "Location" "/login"}
      :session (assoc (:session request) :user {:oauth-github-id oauth-github-id})
-     ;; Hier werden für demonstrationszwecke ein paar Daten angezeigt
-     ;; Der frontend code könnte hier die Bestätigung bekommen,
-     ;; dass der Login funktioniert hat
      :body (str github-data)}))
 
 
@@ -127,14 +123,11 @@
   [handler]
   (fn [request]
     (case (:uri request)
-      ;; Der authenticate-session call darf nicht abgefangen werden,
-      ;; daher wird dieser hier gehandhabt
+      ;; The call to authenticate the session should be available to users that are not 
+      ;; already authenticated.
       "/oauth2/github/callback-success" (authenticate-session request)
-      ;; Prüfen ob der Nutzer eingeloggt ist
       (if (is-authenticated? request)
-        ;; Nutzer darf alles machen
         (handler request)
-        ;; Nutzer muss sich authentifizieren
         {:status 401
          :body "Unauthorized"}))))
 

--- a/src/clj/auth.clj
+++ b/src/clj/auth.clj
@@ -89,10 +89,12 @@
 ;; Github ID zur Session hinzufügen
 (defn- authenticate-session
   [request]
-  (let [github-data (github-user-data-from-token (extract-token request))]
+  (let [github-data (github-user-data-from-token (extract-token request))
+        oauth-github-id (github-data :id)]
+
     {:status 307
      :headers {"Content-Type" "text/plain", "Location" "/"}
-     :session (assoc (:session request) :user github-data)
+     :session (assoc (:session request) :user {:oauth-github-id oauth-github-id})
      ;; Hier werden für demonstrationszwecke ein paar Daten angezeigt
      ;; Der frontend code könnte hier die Bestätigung bekommen,
      ;; dass der Login funktioniert hat

--- a/src/clj/auth.clj
+++ b/src/clj/auth.clj
@@ -93,7 +93,7 @@
         oauth-github-id (github-data :id)]
 
     {:status 307
-     :headers {"Content-Type" "text/plain", "Location" "/"}
+     :headers {"Content-Type" "text/plain", "Location" "/login"}
      :session (assoc (:session request) :user {:oauth-github-id oauth-github-id})
      ;; Hier werden für demonstrationszwecke ein paar Daten angezeigt
      ;; Der frontend code könnte hier die Bestätigung bekommen,

--- a/src/clj/controllers/user/user_controller.clj
+++ b/src/clj/controllers/user/user_controller.clj
@@ -1,0 +1,29 @@
+(ns controllers.user.user-controller
+  (:require
+    [auth]
+    [clojure.spec.alpha :as s]
+    [ring.util.response :refer [redirect]]
+    [services.user-service.p-user-service :refer [PUserService 
+                                                  get-user-id-by-git-id]]))
+
+
+(s/fdef login
+        :args (s/cat :req coll?
+                     :user-service #(satisfies? PUserService %))
+        :ret (s/keys :req-un [::status ::body]))
+
+
+(defn login
+  "Tries to login the user based on their GitHub Authentication"
+  [req user-service]
+  (if (not (auth/is-authenticated? req))
+    ;; Redirect to GitHub oauth if not authenticated
+    (redirect "/oauth2/github")
+    ;; else search user in the database and put it into the session or redirect to user creation
+    (let [session (req :session)
+          oauth-github-id (-> session :user :oauth-github-id)
+          [user-id] (get-user-id-by-git-id user-service (str (-> session :user :oauth-github-id)))]
+      (if user-id
+        (-> (redirect "/") (assoc :session {:user {:id user-id :oauth-github-id oauth-github-id}}))
+        (redirect "/")))))
+

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -38,7 +38,7 @@
 ;; all routes that dont need authentication go here
 (defroutes public-routes
   (GET "/" req (html-response
-                 (if (auth/is-logged-in req)
+                 (if (auth/is-logged-in? req)
                    [:p (str "Hello, " (str (get-in req [:session :user :id])))]
                    [:a {:href "/oauth2/github"} "Login"])))) ; TODO remove route, just an example to show login working
 

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -8,6 +8,7 @@
     [controllers.course.course-controller :refer [create-course-get submit-create-course!]]
     [controllers.question.question-controller :refer [create-question-get
                                                       submit-create-question!]]
+    [controllers.user.user-controller :refer [login]]
     [db]
     [domain]
     [ring.adapter.jetty :refer [run-jetty]]
@@ -22,6 +23,7 @@
     [services.question-service.question-service :refer [->QuestionService]]
     [services.question-set-service.p-question-set-service :refer [get-all-question-sets]]
     [services.question-set-service.question-set-service :refer [->QuestionSetService]]
+    [services.user-service.user-service :refer [->UserService]]
     [util.ring-extensions :refer [html-response]]))
 
 
@@ -32,7 +34,8 @@
   {:course-service (->CourseService db)
    :course-iteration-service (->CourseIterationService db)
    :question-set-service (->QuestionSetService db)
-   :question-service (->QuestionService db)})
+   :question-service (->QuestionService db)
+   :user-service (->UserService db)})
 
 
 ;; all routes that dont need authentication go here
@@ -40,8 +43,8 @@
   (GET "/" req (html-response
                  (if (auth/is-logged-in? req)
                    [:p (str "Hello, " (str (get-in req [:session :user :id])))]
-                   [:a {:href "/oauth2/github"} "Login"])))) ; TODO remove route, just an example to show login working
-
+                   [:a {:href "/login"} "Login"]))) ; TODO remove route, just an example to show login working
+  (GET "/login" req (login req (services :user-service))))
 
 
 ;; all routes that require authentication go here

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -8,7 +8,7 @@
     [controllers.course.course-controller :refer [create-course-get submit-create-course!]]
     [controllers.question.question-controller :refer [create-question-get
                                                       submit-create-question!]]
-    [controllers.user.user-controller :refer [login]]
+    [controllers.user.user-controller :refer [login create-user-get submit-create-user]]
     [db]
     [domain]
     [ring.adapter.jetty :refer [run-jetty]]
@@ -44,7 +44,9 @@
                  (if (auth/is-logged-in? req)
                    [:p (str "Hello, " (str (get-in req [:session :user :id])))]
                    [:a {:href "/login"} "Login"]))) ; TODO remove route, just an example to show login working
-  (GET "/login" req (login req (services :user-service))))
+  (GET "/login" req (login req (services :user-service)))
+  (GET "/create-user" req (html-response (create-user-get req "/create-user" (services :user-service))))
+  (POST "/create-user" req (submit-create-user req "/login" (services :user-service))))
 
 
 ;; all routes that require authentication go here

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -108,7 +108,11 @@
 
   (get-user-by-git-id
     [this git-id]
-    "get the user given the git-id of the user"))
+    "get the user given the git-id of the user. This function throws an error in case the user does not exist.")
+
+  (get-user-id-by-git-id
+    [this git-id]
+    "get the user id given the git-id of the user. This function returns nil in case the user does not exist."))
 
 
 (deftype Database
@@ -480,7 +484,17 @@
     [this git-id]
     (d/pull @(.conn this)
             [:user/id :user/git-id :user/course-iterations]
-            [:user/git-id git-id])))
+            [:user/git-id git-id]))
+
+
+  (get-user-id-by-git-id
+    [this git-id]
+    (first (d/q '[:find ?id
+                  :in $ ?git-id
+                  :where
+                  [?e :user/git-id ?git-id]
+                  [?e :user/id ?id]]
+                @(.conn this) git-id))))
 
 
 ;; use mem db

--- a/src/clj/services/user_service/p_user_service.clj
+++ b/src/clj/services/user_service/p_user_service.clj
@@ -1,0 +1,16 @@
+(ns services.user-service.p-user-service)
+
+
+(defprotocol PUserService
+
+  (create-user!
+    [self oauth-github-id]
+    "Creates a new user entry in the database and returns it.")
+
+  (git-id-in-use?
+    [self oauth-github-id]
+    "Checks if the given github-id is already in use or not. Returns true or false.")
+
+  (get-user-id-by-git-id
+    [self oauth-github-id]
+    "Gets the user id associated with the given github-id, returns nil if there is none."))

--- a/src/clj/services/user_service/user_service.clj
+++ b/src/clj/services/user_service/user_service.clj
@@ -1,0 +1,47 @@
+(ns services.user-service.user-service
+  (:require
+    [clojure.spec.alpha :as s]
+    [db]
+    [services.user-service.p-user-service :refer [PUserService]]))
+
+
+(deftype UserService
+  [db])
+
+
+(s/fdef create-user-impl
+        :args (s/cat :self #(satisfies? PUserService %)
+                     :oauth-github-id :general/non-blank-string)
+        :ret (s/keys :req [:user/id
+                           :user/git-id
+                           :user/course-iterations]))
+
+
+(defn- create-user-impl
+  [this oauth-github-id]
+  (db/add-user! (.db this) oauth-github-id))
+
+
+(s/fdef git-id-in-use?-impl
+        :args (s/cat :self #(satisfies? PUserService %)
+                     :oauth-github-id :general/non-blank-string)
+        :ret boolean?)
+
+
+(defn- git-id-in-use?-impl
+  [this oauth-github-id]
+  (boolean (db/get-user-id-by-git-id (.db this) oauth-github-id)))
+
+
+(s/fdef get-user-id-by-git-id-impl
+        :args (s/cat :self #(satisfies? PUserService %)
+                     :oauth-github-id :general/non-blank-string)
+        :ret (s/or :user-id int? :nil nil?))
+
+
+(defn- get-user-id-by-git-id-impl
+  [this oauth-github-id]
+  (db/get-user-id-by-git-id (.db this) oauth-github-id))
+
+
+(extend UserService PUserService {:create-user! create-user-impl :git-id-in-use? git-id-in-use?-impl :get-user-id-by-git-id get-user-id-by-git-id-impl})

--- a/src/clj/views/user/create_user_view.clj
+++ b/src/clj/views/user/create_user_view.clj
@@ -1,0 +1,25 @@
+(ns views.user.create-user-view
+  (:require
+    [clojure.spec.alpha :as s]
+    [hiccup.form :as hform]
+    [hiccup2.core :as h]
+    [ring.util.anti-forgery :refer [anti-forgery-field]]))
+
+
+(s/fdef create-user-form
+        :args (s/cat :post-destination :general/non-blank-string)
+        :ret #(instance? hiccup.util.RawString %))
+
+
+(defn create-user-form
+  "Returns an html-form which is used to create a user.
+   Currently there are no inputs in this form, but some things like the 'unikennung',
+   a name and something like that should probably be included here."
+  [post-destination]
+  (hform/form-to
+    [:post post-destination]
+    ;; TODO: maybe ask about name, mail, unikennung?
+    [:div "Für diesen GitHub Account ist noch kein User hinterlegt."]
+
+    (h/raw (anti-forgery-field))
+    (hform/submit-button "User für diesen GitHub Account erstellen")))

--- a/test/controllers/user/user_controller_test.clj
+++ b/test/controllers/user/user_controller_test.clj
@@ -1,0 +1,61 @@
+(ns controllers.user.user-controller-test
+  (:require
+    [clojure.test :as t :refer [deftest testing]]
+    [controllers.user.user-controller :refer [login submit-create-user]]
+    [services.user-service.p-user-service :refer [PUserService]]))
+
+
+(def authenticated-session {:user {:oauth-github-id "git-id"}})
+
+
+(deftest test-login
+  (testing "unauthenticated login request is redirected to oauth"
+    (let [request {}
+          user-service (reify PUserService)
+          response (login request user-service)]
+      (t/is (= 302 (response :status)))
+      (t/is (= "/oauth2/github" (get-in response [:headers "Location"])))
+      (t/is (nil? (-> response :session :user :id)))))
+  (testing "authenticated login is logged in, when user exists"
+    (let [request {:session authenticated-session}
+          user-service (reify PUserService
+                         (get-user-id-by-git-id
+                           [_self _git-id]
+                           "some-user-id"))
+          response (login request user-service)]
+      (t/is (-> response :session :user :id))))
+  (testing "authenticated login is redirected to create user page, when user doesn't exist"
+    (let [request {:session authenticated-session}
+          user-service (reify PUserService
+                         (get-user-id-by-git-id
+                           [_self _git-id]
+                           nil))
+          response (login request user-service)]
+      (t/is (= 302 (response :status)))
+      (t/is (= "/create-user" (get-in response [:headers "Location"])))
+      (t/is (nil? (-> response :session :user :id))))))
+
+
+(deftest test-submit-create-user
+  (testing "submit is unauthorized when git id is already in use"
+    (let [request {:session authenticated-session}
+          user-service (reify PUserService
+                         (git-id-in-use?
+                           [_self _git-id]
+                           true))
+          response (submit-create-user request "/" user-service)]
+      (t/is (= 401 (response :status)))))
+  (testing "The create-user! function is called with the correct values"
+    (let [request {:session authenticated-session}
+          redirect-url "/redirect-url"
+          user-service (reify PUserService
+                         (git-id-in-use?
+                           [_self _git-id]
+                           false)
+
+                         (create-user!
+                           [_self git-id]
+                           (t/is (= git-id (-> request :session :user :oauth-github-id)))))
+          response (submit-create-user request redirect-url user-service)]
+      (t/is (= 302 (response :status)))
+      (t/is (= redirect-url (get-in response [:headers "Location"]))))))

--- a/test/services/user_service/user_service_test.clj
+++ b/test/services/user_service/user_service_test.clj
@@ -1,0 +1,61 @@
+(ns services.user-service.user-service-test
+  (:require
+    [clojure.test :as t :refer [deftest testing]]
+    [db :refer [Database-Protocol]]
+    [services.user-service.p-user-service :refer [create-user! get-user-id-by-git-id git-id-in-use?]]
+    [services.user-service.user-service :refer [->UserService]]))
+
+
+(deftest test-git-id-in-use?
+  (testing "UserService implementation calls database query for user id by git id."
+    (let [was-called (atom false)
+          db-stub (reify Database-Protocol
+                    (get-user-id-by-git-id
+                      [_this _git-id]
+                      (swap! was-called (fn [_] true))
+                      {}))
+          user-service (->UserService db-stub)]
+      (git-id-in-use? user-service "some-git-id")
+      (t/is @was-called)))
+  (testing "Returns false if no user exists for git-id"
+    (let [db-stub (reify Database-Protocol
+                    (get-user-id-by-git-id
+                      [_this _git-id]
+                      nil))
+          user-service (->UserService db-stub)
+          result (git-id-in-use? user-service "some-git-id")]
+      (t/is (= result false))))
+  (testing "Returns true if user exists for git-id"
+    (let [db-stub (reify Database-Protocol
+                    (get-user-id-by-git-id
+                      [_this _git-id]
+                      "some-user-id"))
+          user-service (->UserService db-stub)
+          result (git-id-in-use? user-service "some-git-id")]
+      (t/is (= result true)))))
+
+
+(deftest test-create-user
+  (testing "UserService implementation calls database query to create a user"
+    (let [was-called (atom false)
+          db-stub (reify Database-Protocol
+                    (add-user!
+                      [_this _git-id]
+                      (swap! was-called (fn [_] true))
+                      {}))
+          user-service (->UserService db-stub)]
+      (create-user! user-service "some-git-id"))))
+
+
+(deftest test-get-user-id-by-git-id
+  (testing "UserService implementation calls database query for user id by git id"
+    (let [was-called (atom false)
+          db-stub (reify Database-Protocol
+                    (get-user-id-by-git-id
+                      [_this _git-id]
+                      (swap! was-called (fn [_] true))
+                      {}))
+          user-service (->UserService db-stub)]
+      (get-user-id-by-git-id user-service "some-git-id")
+      (t/is @was-called))))
+


### PR DESCRIPTION
This PR updates the login process, so that after being redirected from github it is checked if the user is registered in our application.
If not a new user can be created.

It also adds (empty) `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET_ID` environment variables in our CI during the test step, which was previously not necessary because the Code in `auth.clj` wasn't tested.