### PR TITLE
83 create a correction overview view

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,6 @@
 {:linters {:unresolved-var {:exclude [hiccup.form/form-to
                                       hiccup.form/select-options
-                                      hiccup.form/submit-button]}}}
+                                      hiccup.form/submit-button
+                                      hiccup.form/radio-button
+                                      hiccup.form/text-area
+                                      hiccup.form/check-box]}}}

--- a/src/clj/controllers/correction/correction_controller.clj
+++ b/src/clj/controllers/correction/correction_controller.clj
@@ -31,6 +31,6 @@
                          (sort-by #(% :correction/timestamp))
                          (drop (* page-size (dec active-page)))
                          (take page-size))
-        number-of-pages (int (Math/ceil (/ (count corrections) page-size)))]
+        number-of-pages (max 1 (int (Math/ceil (/ (count corrections) page-size))))]
 
     (view/correction-overview page-result tabs active-tab number-of-pages active-page)))

--- a/src/clj/controllers/correction/correction_controller.clj
+++ b/src/clj/controllers/correction/correction_controller.clj
@@ -1,0 +1,36 @@
+(ns controllers.correction.correction-controller
+  (:require
+    [clojure.spec.alpha :as s]
+    [db]
+    [services.correction-service.p-correction-service :refer [PCorrectionService get-corrections-from-user-as]]
+    [views.correction.correction-overview-view :as view]))
+
+
+(def page-size 3)
+
+(def tabs {"corrections" "Korrekturen", "corrected" "Von mir korrigierte Abgaben"})
+
+
+(s/fdef correction-overview-get
+        :args (s/cat :req coll?
+                     :correction-service #(satisfies? PCorrectionService %))
+        :ret #(instance? hiccup.util.RawString %))
+
+
+(defn correction-overview-get
+  [req correction-service]
+  (let [tab-param (get-in req [:params :tab] "corrections")
+        active-tab (if (contains? tabs tab-param) tab-param "corrections")
+        active-page (try (Integer/parseInt (get-in req [:params :page] "1")) (catch Exception _e 1))
+        user-id (-> req :session :user :id)
+        corrections    (case active-tab
+                         "corrections" (get-corrections-from-user-as correction-service user-id :student)
+                         "corrected" (get-corrections-from-user-as correction-service user-id :corrector)
+                         [])
+        page-result (->> corrections
+                         (sort-by #(% :correction/timestamp))
+                         (drop (* page-size (dec active-page)))
+                         (take page-size))
+        number-of-pages (int (Math/ceil (/ (count corrections) page-size)))]
+
+    (view/correction-overview page-result tabs active-tab number-of-pages active-page)))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -5,6 +5,7 @@
     [compojure.core :refer [defroutes GET POST PUT]]
     [compojure.route :as route]
     [controllers.answer.answer-controller :refer [submit-user-answer!]]
+    [controllers.correction.correction-controller :refer [correction-overview-get]]
     [controllers.course-iteration.course-iteration-controller :refer [create-course-iteration-get submit-create-course-iteration!]]
     [controllers.course.course-controller :refer [create-course-get submit-create-course!]]
     [controllers.question-set.question-set-controller :refer [question-set-get]]
@@ -20,6 +21,7 @@
     [ring.middleware.reload :refer [wrap-reload]]
     [ring.middleware.resource :refer [wrap-resource]]
     [services.answer-service.answer-service :refer [->AnswerService]]
+    [services.correction-service.correction-service :refer [->CorrectionService]]
     [services.course-iteration-service.course-iteration-service :refer [->CourseIterationService]]
     [services.course-service.course-service :refer [->CourseService]]
     [services.course-service.p-course-service :refer [get-all-courses]]
@@ -41,7 +43,8 @@
    :question-set-service (->QuestionSetService db)
    :question-service (->QuestionService db)
    :answer-service (->AnswerService db)
-   :user-service (->UserService db)})
+   :user-service (->UserService db)
+   :correction-service (->CorrectionService db)})
 
 
 ;; all routes that dont need authentication go here
@@ -91,6 +94,9 @@
         (submit-create-course-iteration! req "/create-course-iteration" (:course-iteration-service services)))
 
   (GET "/private" _ "Only for logged in users.") ; TODO remove route, just example to show authenticated routes working
+
+  (GET "/correction-overview" req
+       (html-response (correction-overview-get req (services :correction-service))))
 
   (route/not-found "Not Found"))
 

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -538,16 +538,16 @@
       (d/q '[:find ?feedback ?points-reached ?reachable-points ?question-statement ?timestamp ?answers
              :in $ ?user-id
              :where
-             [?correction :correction/answer ?answer]
-             [?correction :correction/feedback ?feedback ?tx]
+             [?user :user/id ?user-id]
              [?answer :answer/user ?user]
              [?answer :answer/points ?points-reached]
              [?answer :answer/answer ?answers]
              [?answer :answer/question ?question]
+             [?correction :correction/answer ?answer]
+             [?correction :correction/feedback ?feedback ?tx]
              [?question :question/question-statement ?question-statement]
              [?question :question/points ?reachable-points]
-             [?tx :db/txInstant ?timestamp]
-             [?user :user/id ?user-id]]
+             [?tx :db/txInstant ?timestamp]]
            @(.conn this) user-id)))
 
 
@@ -558,16 +558,16 @@
       (d/q '[:find ?feedback ?points-reached ?reachable-points ?question-statement ?timestamp ?answers
              :in $ ?user-id
              :where
-             [?correction :correction/answer ?answer]
-             [?correction :correction/feedback ?feedback ?tx]
+             [?user :user/id ?user-id]
              [?correction :correction/corrector ?user]
+             [?correction :correction/feedback ?feedback ?tx]
+             [?correction :correction/answer ?answer]
              [?answer :answer/points ?points-reached]
              [?answer :answer/answer ?answers]
              [?answer :answer/question ?question]
              [?question :question/question-statement ?question-statement]
              [?question :question/points ?reachable-points]
-             [?tx :db/txInstant ?timestamp]
-             [?user :user/id ?user-id]]
+             [?tx :db/txInstant ?timestamp]]
            @(.conn this) corrector-id))))
 
 

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -119,7 +119,15 @@
 
   (get-user-id-by-git-id
     [this git-id]
-    "get the user id given the git-id of the user. This function returns nil in case the user does not exist."))
+    "get the user id given the git-id of the user. This function returns nil in case the user does not exist.")
+
+  (get-all-corrections-from-user
+    [this user-id]
+    "get all corrections by user-id")
+
+  (get-all-corrections-from-corrector
+    [this corrector-id]
+    "get all corrections by the user-id of the corrector"))
 
 
 (deftype Database
@@ -520,7 +528,47 @@
                   :where
                   [?e :user/git-id ?git-id]
                   [?e :user/id ?id]]
-                @(.conn this) git-id))))
+                @(.conn this) git-id)))
+
+
+  (get-all-corrections-from-user
+    [this user-id]
+    (mapv
+      #(zipmap [:correction/feedback :answer/points :question/points :question/question-statement :correction/timestamp :answer/answer] %)
+      (d/q '[:find ?feedback ?points-reached ?reachable-points ?question-statement ?timestamp ?answers
+             :in $ ?user-id
+             :where
+             [?correction :correction/answer ?answer]
+             [?correction :correction/feedback ?feedback ?tx]
+             [?answer :answer/user ?user]
+             [?answer :answer/points ?points-reached]
+             [?answer :answer/answer ?answers]
+             [?answer :answer/question ?question]
+             [?question :question/question-statement ?question-statement]
+             [?question :question/points ?reachable-points]
+             [?tx :db/txInstant ?timestamp]
+             [?user :user/id ?user-id]]
+           @(.conn this) user-id)))
+
+
+  (get-all-corrections-from-corrector
+    [this corrector-id]
+    (mapv
+      #(zipmap [:correction/feedback :answer/points :question/points :question/question-statement :correction/timestamp :answer/answer] %)
+      (d/q '[:find ?feedback ?points-reached ?reachable-points ?question-statement ?timestamp ?answers
+             :in $ ?user-id
+             :where
+             [?correction :correction/answer ?answer]
+             [?correction :correction/feedback ?feedback ?tx]
+             [?correction :correction/corrector ?user]
+             [?answer :answer/points ?points-reached]
+             [?answer :answer/answer ?answers]
+             [?answer :answer/question ?question]
+             [?question :question/question-statement ?question-statement]
+             [?question :question/points ?reachable-points]
+             [?tx :db/txInstant ?timestamp]
+             [?user :user/id ?user-id]]
+           @(.conn this) corrector-id))))
 
 
 ;; use mem db

--- a/src/clj/services/correction_service/correction_service.clj
+++ b/src/clj/services/correction_service/correction_service.clj
@@ -1,0 +1,26 @@
+(ns services.correction-service.correction-service
+  (:require
+    [clojure.spec.alpha :as s]
+    [db]
+    [services.correction-service.p-correction-service :refer [PCorrectionService]]))
+
+
+(deftype CorrectionService
+  [db])
+
+
+(s/fdef get-corrections-from-user-as-impl
+        :args (s/cat :self #(satisfies? PCorrectionService %)
+                     :user-id :user/id
+                     :role #(contains? #{:student :corrector} %)))
+
+
+(defn- get-corrections-from-user-as-impl
+  [this user-id role]
+  (case role
+    :student (db/get-all-corrections-from-user (.db this) user-id)
+    :corrector (db/get-all-corrections-from-corrector (.db this) user-id)
+    []))
+
+
+(extend CorrectionService PCorrectionService {:get-corrections-from-user-as get-corrections-from-user-as-impl})

--- a/src/clj/services/correction_service/p_correction_service.clj
+++ b/src/clj/services/correction_service/p_correction_service.clj
@@ -1,0 +1,8 @@
+(ns services.correction-service.p-correction-service)
+
+
+(defprotocol PCorrectionService
+
+  (get-corrections-from-user-as
+    [self user-id role]
+    "Gets the corrections from a single user by their role. (Either :corrector or :student (for now, roles aren't yet implemented to this extent))"))

--- a/src/clj/views/correction/correction_overview_view.clj
+++ b/src/clj/views/correction/correction_overview_view.clj
@@ -1,5 +1,6 @@
 (ns views.correction.correction-overview-view
   (:require
+    [clojure.spec.alpha :as s]
     [hiccup2.core :as h]))
 
 
@@ -53,6 +54,22 @@
             (card-entry "Feedback:" (correction :correction/feedback))
             (card-entry "Punkte:" (str (correction :answer/points) " von " (correction :question/points)))]]])
        corrections))
+
+
+(s/def ::correction (s/keys :req [:correction/feedback :answer/points :question/points :question/question-statement :answer/answer]))
+
+
+(s/fdef correction-overview
+        :args (s/and (s/cat :corrections (s/coll-of ::correction)
+                            :tabs (s/map-of :general/non-blank-string :general/non-blank-string)
+                            :active-tab :general/non-blank-string
+                            :number-of-pages pos-int?
+                            :active-page pos-int?)
+                     #(> (:active-page %) 0)
+                     #(> (:number-of-pages %) 0)
+                     #(>= (:number-of-pages %) (:active-page %))
+                     #(contains? (:tabs %) (:active-tab %)))
+        :ret  #(instance? hiccup.util.RawString %))
 
 
 (defn correction-overview

--- a/src/clj/views/correction/correction_overview_view.clj
+++ b/src/clj/views/correction/correction_overview_view.clj
@@ -1,0 +1,67 @@
+(ns views.correction.correction-overview-view
+  (:require
+    [hiccup2.core :as h]))
+
+
+(defn- page-query-params
+  [active-tab page]
+  (str "?tab=" active-tab "&page=" page))
+
+
+(defn- tab-item
+  [label href class]
+  [:li.nav-item
+   [:a.nav-link {:href href :class class} label]])
+
+
+(defn- nav-tabs
+  [tabs active-tab]
+  [:ul.nav.nav-tabs
+   (map (fn [[tab-name label]] (tab-item label (page-query-params tab-name 1) (if (= tab-name active-tab) "active" nil))) tabs)])
+
+
+(defn- page-item
+  [label href class]
+  [:li.page-item {:class class}
+   [:a.page-link {:href href} label]])
+
+
+(defn- pagination
+  [number-of-pages active-page active-tab]
+  [:nav
+   [:ul.pagination
+    (page-item "Previous" (page-query-params active-tab (dec active-page)) (if (= 1 active-page) "disabled" nil))
+    (map (fn [page]
+           (page-item page (page-query-params active-tab page) (if (= page active-page) "active" nil)))
+         (range 1 (inc number-of-pages)))
+    (page-item "Next" (page-query-params active-tab (inc active-page)) (if (= number-of-pages active-page) "disabled" nil))]])
+
+
+(defn- card-entry
+  [label value]
+  [:p [:span.font-weight-bold.mr-1 label] value])
+
+
+(defn- display-corrections
+  [corrections]
+  (map (fn [correction]
+         [:div.card.my-2
+          [:div.card-body
+           [:h5.card-title (correction :question/question-statement)]
+           [:div.card-text
+            (card-entry "Gegebene Antwort:" (or (not-empty (correction :answer/answer)) "Keine Antwort gegeben"))
+            (card-entry "Feedback:" (correction :correction/feedback))
+            (card-entry "Punkte:" (str (correction :answer/points) " von " (correction :question/points)))]]])
+       corrections))
+
+
+(defn correction-overview
+  [corrections tabs active-tab number-of-pages active-page]
+  (h/html
+    [:div
+     [:h2 "Korrektur Übersicht"]
+
+     (nav-tabs tabs active-tab)
+     (display-corrections corrections)
+     (pagination number-of-pages active-page active-tab)]))
+

--- a/src/clj/views/template.clj
+++ b/src/clj/views/template.clj
@@ -18,7 +18,8 @@
        [["Login" "/login" not-logged-in]
         ["Home" "/" is-logged-in?]
         ["Create Course Iteration" "/create-course-iteration" is-logged-in?]  ; FIXME: Check for admin permissions
-        ["Create Question" "/create-question" is-logged-in?]]))  ; FIXME: Check for admin permissions
+        ["Create Question" "/create-question" is-logged-in?] ; FIXME: Check for admin permissions
+        ["Correction Overview" "/correction-overview" is-logged-in?]]))  ; FIXME: Check for admin permissions
 
 
 ;; this is the bootstrap 4.0 example "stick-footer-navbar" without the javascript

--- a/test/controllers/correction/correction_controller_test.clj
+++ b/test/controllers/correction/correction_controller_test.clj
@@ -1,0 +1,40 @@
+(ns controllers.correction.correction-controller-test
+  (:require
+    [clojure.test :as t :refer [deftest testing]]
+    [controllers.correction.correction-controller :refer [correction-overview-get]]
+    [services.correction-service.p-correction-service :refer [PCorrectionService]]))
+
+
+(defn- request
+  [tab page _user-id]
+  {:params {:tab tab :page page} :session {:user {:id "0"}}})
+
+
+(deftest test-correction-overview-get
+  (testing "Correction service is called with correct params on 'corrections' tab"
+    (let [was-called (atom false)
+          user-id-param "0"
+          req (request "corrections" "1" user-id-param)
+          correction-service (reify PCorrectionService
+                               (get-corrections-from-user-as
+                                 [_self user-id role]
+                                 (swap! was-called (fn [_] true))
+                                 (t/is (= user-id user-id-param))
+                                 (t/is (= role :student))
+                                 nil))]
+      (correction-overview-get req correction-service)
+      (t/is @was-called)))
+
+  (testing "Correction service is called with correct params on 'corrected' tab"
+    (let [was-called (atom false)
+          user-id-param "0"
+          req (request "corrected" "1" user-id-param)
+          correction-service (reify PCorrectionService
+                               (get-corrections-from-user-as
+                                 [_self user-id role]
+                                 (swap! was-called (fn [_] true))
+                                 (t/is (= user-id user-id-param))
+                                 (t/is (= role :corrector))
+                                 nil))]
+      (correction-overview-get req correction-service)
+      (t/is @was-called))))

--- a/test/services/correction_service/correction_service_test.clj
+++ b/test/services/correction_service/correction_service_test.clj
@@ -1,0 +1,33 @@
+(ns services.correction-service.correction-service-test
+  (:require
+    [clojure.test :as t :refer [deftest testing]]
+    [db :refer [Database-Protocol]]
+    [services.correction-service.correction-service :refer [->CorrectionService]]
+    [services.correction-service.p-correction-service :refer [get-corrections-from-user-as]]))
+
+
+(deftest test-get-corrections-from-user-as
+  (testing "CorrectionService implementation calls database query for the :student role"
+    (let [was-called (atom false)
+          user-id-param "0"
+          db-stub (reify Database-Protocol
+                    (get-all-corrections-from-user
+                      [_this user-id]
+                      (swap! was-called (fn [_] true))
+                      (t/is (= user-id user-id-param))
+                      []))
+          correction-service (->CorrectionService db-stub)]
+      (get-corrections-from-user-as correction-service user-id-param :student)
+      (t/is @was-called)))
+  (testing "CorrectionService implementation calls database query for the :corrector role"
+    (let [was-called (atom false)
+          user-id-param "0"
+          db-stub (reify Database-Protocol
+                    (get-all-corrections-from-corrector
+                      [_this user-id]
+                      (swap! was-called (fn [_] true))
+                      (t/is (= user-id user-id-param))
+                      []))
+          correction-service (->CorrectionService db-stub)]
+      (get-corrections-from-user-as correction-service user-id-param :corrector)
+      (t/is @was-called))))

--- a/test/view/correction/correction_overview_view_test.clj
+++ b/test/view/correction/correction_overview_view_test.clj
@@ -1,0 +1,39 @@
+(ns view.correction.correction-overview-view-test
+  (:require
+    [clojure.spec.alpha :as s]
+    [clojure.string :as string]
+    [clojure.test :as t :refer [deftest testing]]
+    [clojure.test.check :as tc]
+    [clojure.test.check.generators :as gen]
+    [clojure.test.check.properties :as prop]
+    [views.correction.correction-overview-view :refer [correction-overview]]))
+
+
+(def page-args-gen
+  (gen/let [number-of-pages (gen/such-that #(< 0 %) gen/nat)
+            active-page (gen/choose 1 number-of-pages)]
+    {:number-of-pages number-of-pages :active-page active-page}))
+
+
+(def tab-args-gen
+  (gen/let [tabs (gen/map (gen/not-empty gen/string-alphanumeric) (gen/not-empty gen/string-alphanumeric) {:min-elements 1})
+            active-tab (gen/elements (vec (keys tabs)))]
+    {:tabs tabs :active-tab active-tab}))
+
+
+(def correction-gen (s/gen (s/keys :req [:correction/feedback :answer/points :question/points :question/question-statement :answer/answer])))
+
+
+(deftest test-correction-overview
+  (testing "Test that overview contains all information from the corrections"
+    (tc/quick-check 50 (prop/for-all [corrections (gen/vector correction-gen)
+                                      {tabs :tabs active-tab :active-tab} tab-args-gen
+                                      {number-of-pages :number-of-pages active-page :active-page} page-args-gen]
+                                     (let [correction-overview (correction-overview corrections tabs active-tab number-of-pages active-page)]
+                                       (t/is (every? #(string/includes? correction-overview (:correction/feedback %)) corrections))
+                                       (t/is (every? #(string/includes? correction-overview (first (:answer/answer %))) (filter #(not-empty (:answer/answer %)) corrections)))
+
+                                       (t/is (every? #(string/includes? correction-overview (str (:answer/points %))) corrections))
+                                       (t/is (every? #(string/includes? correction-overview (str (:question/points %))) corrections))
+                                       (t/is (every? #(string/includes? correction-overview (:question/question-statement %)) corrections)))))))
+


### PR DESCRIPTION
This adds an overview for corrections to the app.
You can toggle between the corrected answers of your user account and the corrections you gave to the answers of other users.
The paging/tabs are solved with get Parameters + Bootstrap, so no additional javascript is used.
![Screenshot from 2023-08-11 12-14-25](https://github.com/pkoerner/expert-parakeet/assets/44272737/a9ba6703-6449-49c4-86d5-1d72afe5d489)
