### PR TITLE
Fix server error when trying to load '/user-overview'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.clj-kondo/config.edn
 .cpcache
 .lsp
+.portal/
 /expert-parakeet.iml
 .shadow-cljs/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN clj -T:build clean
 
 COPY Makefile /tmp/
 COPY src /tmp/src
-RUN make compile-cljs
 COPY resources /tmp/resources
 RUN make uber
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 .PHONY: dev-server format test lint uber
-dev-server:
+# this rule is first, so that just running 'make' will start the server
+dev-server: compile-cljs
 	clj -X core/start-dev-server
 
 format:
 	clj -M:format
 
-test:
+test: compile-cljs
 	clj -M:test-runner
 
 lint:
 	clj -M:lint
 
-uber:
+uber: compile-cljs
 	clj -T:build uber
 
 compile-cljs:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ export OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET
 ## Run Development Server
 
 ```shell
+make
+# or
 make dev-server
 ```
 

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -64,8 +64,11 @@
 
 ;; all routes that require authentication go here
 (defroutes private-routes
+  (GET "/private" _ "Only for logged in users.") ; TODO remove route, just example to show authenticated routes working 
+
   (GET "/user-overview" req (let [user-git-id (str (get-in req [:session :user :oauth-github-id]))]
-                              (create-user-overview-get (get-all-course-iterations-for-user (:course-iteration-service services) user-git-id))))
+                              (html-response (create-user-overview-get (get-all-course-iterations-for-user (:course-iteration-service services) user-git-id)))))
+
   (GET "/question-set/:id"
        req
        (html-response (question-set-get req (:question-set-service services))))
@@ -89,7 +92,6 @@
 
   (POST "/create-course" req
         (submit-create-course! req "/create-course" (:course-service services)))
-  (GET "/private" _ "Only for logged in users.") ; TODO remove route, just example to show authenticated routes working 
 
   (GET "/create-course-iteration" req
        (html-response (create-course-iteration-get req "/create-course-iteration"
@@ -97,8 +99,6 @@
                                                    (partial get-all-question-sets (:question-set-service services)))))
   (POST "/create-course-iteration" req
         (submit-create-course-iteration! req "/create-course-iteration" (:course-iteration-service services)))
-
-  (GET "/private" _ "Only for logged in users.") ; TODO remove route, just example to show authenticated routes working
 
   (GET "/correction-overview" req
        (html-response (correction-overview-get req (services :correction-service))))


### PR DESCRIPTION
When trying to test the routes I encountered a server error.
I fixed it by wrapping the (HTML) response in `html-response`.

My Portal VS Code plugin also generated some files that need to be ignored and the ClojureScript compile rule was not run when starting the dev server via `make` which created some problems for me.