### PR TITLE
Add course association when creating questions

### DIFF
--- a/src/clj/db/schema.clj
+++ b/src/clj/db/schema.clj
@@ -136,7 +136,13 @@
    #:db{:ident :question/categories
         :valueType :db.type/string
         :cardinality :db.cardinality/many
-        :doc "Categories/Tags for this question"}])
+        :doc "Categories/Tags for this question"}
+
+   ;; :question/course 
+   #:db{:ident :question/course
+        :valueType :db.type/ref
+        :cardinality :db.cardinality/one
+        :doc "The course this question belongs to"}])
 
 
 (def answer-slim-pull
@@ -266,7 +272,7 @@
 (def course-slim-pull
   [:course/id
    :course/name
-   {:course/question-sets question-set-no-questions-pull}
+   ;; {:course/question-sets question-set-no-questions-pull}
    ;; no questions for slim pull
    ])
 
@@ -289,10 +295,12 @@
         :valueType :db.type/string
         :cardinality :db.cardinality/one
         :doc "Name of this course"}
-   #:db{:ident :course/questions
-        :valueType :db.type/ref
-        :cardinality :db.cardinality/many
-        :doc "All questions owned by this course"}
+   ;; entfernen da N:M , und nicht 1:n wie im db schema, also Redundanz vermieden(keine doppelt gespeicherten Informationen) ?
+   ;; #:db{:ident :course/questions
+   ;;     :valueType :db.type/ref
+   ;;     :cardinality :db.cardinality/many
+   ;;    :doc "All questions owned by this course"}
+   ;; hier auch entfernen
    #:db{:ident :course/question-sets
         :valueType :db.type/ref
         :cardinality :db.cardinality/many

--- a/src/clj/services/question_service/p_question_service.clj
+++ b/src/clj/services/question_service/p_question_service.clj
@@ -12,7 +12,7 @@
     "Checks if a user is assgined to a certain question.")
 
   (create-question!
-    [self question]
+    [self question course-id]
     "Creates a question entry in the database and returns a question map.")
 
   (get-question-categories

--- a/src/clj/services/question_service/question_service.clj
+++ b/src/clj/services/question_service/question_service.clj
@@ -55,13 +55,14 @@
 ;; TODO: the spec for the question argument is incorrect, must not include ids and the solutions must be strings
 (s/fdef create-question-impl!
         :args (s/cat :self #(= PQuestionService (type %))
-                     :question :question/question)
+                     :question :question/question
+                     :course-id :course/id)
         :ret :question/question)
 
 
 (defn- create-question-impl!
-  [this question]
-  (db/add-question! (.db this) question))
+  [this question course-id]
+  (db/add-question! (.db this) question course-id))
 
 
 (s/fdef get-question-categories

--- a/src/clj/views/question/create_question_view.clj
+++ b/src/clj/views/question/create_question_view.clj
@@ -85,6 +85,7 @@
 
 (s/fdef create-question-form
         :args (s/cat :categories :question/categories
+                     :courses :course/courses
                      :post-destination :general/non-blank-string
                      :kwargs (s/cat :errors (s/? #{:errors})
                                     :error-map (s/? (s/map-of keyword? string?))
@@ -94,14 +95,15 @@
 
 
 (defn create-question-form
-  "Takes as arguments a collection of categories and a destination to which the form's post request should be sent.
+  "Takes as arguments a collection of categories, a collection of courses, 
+   and a destination to which the form's post request should be sent.
    Optional keyword arguemnts:
    `:errors`: Takes a map with form data keys mapped to error messages.
    These are displayed as errors in the form with their corresponding input field.
    `:question-data`: Takes a map with form data keys mapped to values.
    When present, the values are put into the input fields corresponding to the name.
    This way the form can be re-/prepopulated."
-  [categories post-destination & {:keys [errors question-data] :or {errors {} question-data {}}}]
+  [categories courses post-destination & {:keys [errors question-data] :or {errors {} question-data {}}}]
   (let [question-types (->> question-types
                             (map name)
                             (sort))
@@ -119,6 +121,19 @@
        [:h2 "Create question"]
        (hform/form-to
          [:post post-destination]
+
+
+         ;; NEU: Kursauswahl hinzufügen
+         [:div
+          (hform/label {:class "form-label"} "course-id" "Course")
+          (optional-error-display :course errors) ; Kurs-Fehler anzeigen
+          (hform/drop-down {:class "form-select" :required true} "course-id"
+                           (cons ["-- Select a course --" ""]
+                                 (map (fn [course]
+                                        [(:course/name course) (:course/id course)])
+                                      courses))
+                           (get question-data :course-id))]
+
 
          [:div
           (hform/label {:class "form-label"} "statement" "Question statement")


### PR DESCRIPTION
### What’s new?
This PR adds the ability to assign a course to a question when creating it. The main goal is to ensure that questions are properly linked to their respective courses — making the management and organization of questions much easier, especially for future use in course-specific question sets.

### Key changes
- Form update: The question creation form now includes a dropdown to select a course.
- Session fallback: If the course isn't explicitly selected in the form, we fall back to the session or route.
- DB schema: Questions now reference a course in the schema (:question/course), and courses track their questions via :course/questions.
- Logic adjustments: The create-question! function now requires a course-id.
- UI: A new /questions page lists all existing questions and shows their associated course names.