### PR TITLE
Feature/add question to course

### DIFF
--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -69,14 +69,14 @@
     \"categories\" String or array of strings}
    ```"
   [req post-destination question-service]
-  (let [course-id (or (-> req :params :course-id) ; Aus Formular
-                      (-> req :route-params :course-id) ; Aus URL
-                      (-> req :session :course-id)) ; Aus Session
+  (let [course-id (or (-> req :params :course-id) 
+                      (-> req :route-params :course-id) 
+                      (-> req :session :course-id)) 
         form-data (-> req :params (dissoc :__anti-forgery-token))
         question-or-errors (validate-question question-service form-data)
         validation-errors (question-or-errors :errors)]
     (if (empty? validation-errors)
-      (let [added-question (create-question! question-service course-id question-or-errors)] ; NEU: course-id übergeben
+      (let [added-question (create-question! question-service course-id question-or-errors)] 
         (html-response (creation-view/question-success-view added-question)))
       (html-response (creation-view/create-question-form (get-question-categories question-service)
                                                          post-destination

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -36,11 +36,11 @@
    It returns a form for question creation, the result of which will be sent to the provided `post-destination`."
   [req get-question-categories-fun get-courses-fun post-destination]
   (html-response
-   (creation-view/create-question-form
-    (get-question-categories-fun)
-    post-destination
-    :course-id (-> req :session :course-id)
-    :courses (get-courses-fun))))
+    (creation-view/create-question-form
+      (get-question-categories-fun)
+      post-destination
+      :course-id (-> req :session :course-id)
+      :courses (get-courses-fun))))
 
 
 (s/fdef submit-create-question!
@@ -68,18 +68,18 @@
     \"evaluation-criteria\" String,
     \"categories\" String or array of strings}
    ```"
-   [req post-destination question-service]
-   (let [course-id (or (-> req :params :course-id) ; Aus Formular
-                       (-> req :route-params :course-id) ; Aus URL
-                       (-> req :session :course-id)) ; Aus Session
-         form-data (-> req :params (dissoc :__anti-forgery-token))
-         question-or-errors (validate-question question-service form-data)
-         validation-errors (question-or-errors :errors)]
-     (if (empty? validation-errors)
-       (let [added-question (create-question! question-service course-id question-or-errors)] ; NEU: course-id übergeben
-         (html-response (creation-view/question-success-view added-question)))
-       (html-response (creation-view/create-question-form (get-question-categories question-service)
-                                                          post-destination
-                                                          :errors validation-errors
-                                                          :question-data form-data
-                                                          :course-id course-id)))))
+  [req post-destination question-service]
+  (let [course-id (or (-> req :params :course-id) ; Aus Formular
+                      (-> req :route-params :course-id) ; Aus URL
+                      (-> req :session :course-id)) ; Aus Session
+        form-data (-> req :params (dissoc :__anti-forgery-token))
+        question-or-errors (validate-question question-service form-data)
+        validation-errors (question-or-errors :errors)]
+    (if (empty? validation-errors)
+      (let [added-question (create-question! question-service course-id question-or-errors)] ; NEU: course-id übergeben
+        (html-response (creation-view/question-success-view added-question)))
+      (html-response (creation-view/create-question-form (get-question-categories question-service)
+                                                         post-destination
+                                                         :errors validation-errors
+                                                         :question-data form-data
+                                                         :course-id course-id)))))

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -8,7 +8,7 @@
                                                           validate-question
                                                           get-question-by-id
                                                           validate-user-for-question]]
-    [services.question-service.question-service :as q-ser]
+    ;; [services.question-service.question-service :as q-ser]
     [util.ring-extensions :refer [html-response]]
     [views.question.create-question-view :as creation-view]
     [views.question.question-view :as question-view]))

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -69,14 +69,14 @@
     \"categories\" String or array of strings}
    ```"
   [req post-destination question-service]
-  (let [course-id (or (-> req :params :course-id) 
-                      (-> req :route-params :course-id) 
-                      (-> req :session :course-id)) 
+  (let [course-id (or (-> req :params :course-id)
+                      (-> req :route-params :course-id)
+                      (-> req :session :course-id))
         form-data (-> req :params (dissoc :__anti-forgery-token))
         question-or-errors (validate-question question-service form-data)
         validation-errors (question-or-errors :errors)]
     (if (empty? validation-errors)
-      (let [added-question (create-question! question-service course-id question-or-errors)] 
+      (let [added-question (create-question! question-service course-id question-or-errors)]
         (html-response (creation-view/question-success-view added-question)))
       (html-response (creation-view/create-question-form (get-question-categories question-service)
                                                          post-destination

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -30,11 +30,19 @@
 ;;                     :get-question-categories-fun (s/get-spec `q-ser/get-question-categories)
 ;;                     :post-destination string?))
 
+
 (s/fdef create-question-get
-        :args (s/cat :req coll?
-                     :get-question-categories-fun (s/get-spec `q-ser/get-question-categories)
+        :args (s/cat :req map?
+                     :get-question-categories-fun ifn?
                      :get-courses-fun ifn?
                      :post-destination string?))
+
+
+;; (s/fdef create-question-get
+;;        :args (s/cat :req coll?
+;;                     :get-question-categories-fun (s/get-spec `q-ser/get-question-categories)
+;;                     :get-courses-fun ifn?
+;;                     :post-destination string?))
 
 
 (defn create-question-get

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -25,9 +25,15 @@
       (html-response (question-view/no-question-assignment permission-error)))))
 
 
+;; (s/fdef create-question-get
+;;        :args (s/cat :req coll?
+;;                     :get-question-categories-fun (s/get-spec `q-ser/get-question-categories)
+;;                     :post-destination string?))
+
 (s/fdef create-question-get
         :args (s/cat :req coll?
                      :get-question-categories-fun (s/get-spec `q-ser/get-question-categories)
+                     :get-courses-fun ifn?
                      :post-destination string?))
 
 

--- a/src/clj/controllers/question/question_controller.clj
+++ b/src/clj/controllers/question/question_controller.clj
@@ -8,7 +8,7 @@
                                                           validate-question
                                                           get-question-by-id
                                                           validate-user-for-question]]
-    ;; [services.question-service.question-service :as q-ser]
+    [services.question-service.question-service :as q-ser]
     [util.ring-extensions :refer [html-response]]
     [views.question.create-question-view :as creation-view]
     [views.question.question-view :as question-view]))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -105,7 +105,7 @@
 
 
   ;; show all quetions on "http://localhost:8081/questions"
-  (GET "/questions" req
+  (GET "/questions" [_req]  ; req
        (let [db db/create-database
              questions (db/get-all-question-ids db)
              courses (db/get-all-courses db)

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -34,7 +34,8 @@
     [services.question-set-service.question-set-service :refer [->QuestionSetService]]
     [services.user-service.user-service :refer [->UserService]]
     [util.ring-extensions :refer [html-response]]
-    [views.template :refer [wrap-navbar-and-footer]]))
+    [views.template :refer [wrap-navbar-and-footer]]
+    [views.question.questions-overview-view :as questions-overview]))
 
 
 (def db db/create-database)
@@ -111,27 +112,7 @@
           course-map (reduce (fn [m course]
                                (assoc m (:course/id course) (:course/name course)))
                              {} courses)]
-      (html-response
-       [:div.container
-        [:h1 "Fragenübersicht"]
-        [:table.table
-         [:thead
-          [:tr
-           [:th "ID"]
-           [:th "Statement"]
-           [:th "Kurs"]
-           [:th "Aktionen"]]]
-         [:tbody
-          (for [q questions]
-            (let [course-id (-> q :question/course :course/id)
-                  course-name (get course-map course-id "Unbekannter Kurs")]
-              [:tr
-               [:td (:question/id q)]
-               [:td (:question/statement q)]
-               [:td course-name]
-               [:td
-                [:a {:href (str "/question/" (:question/id q))} "Anzeigen"]]]))]]])))
-
+      (html-response (questions-overview/questions-overview questions course-map)))) 
 
 
   (GET "/create-course" req

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -34,8 +34,8 @@
     [services.question-set-service.question-set-service :refer [->QuestionSetService]]
     [services.user-service.user-service :refer [->UserService]]
     [util.ring-extensions :refer [html-response]]
-    [views.template :refer [wrap-navbar-and-footer]]
-    [views.question.questions-overview-view :as questions-overview]))
+    [views.question.questions-overview-view :as questions-overview]
+    [views.template :refer [wrap-navbar-and-footer]]))
 
 
 (def db db/create-database)
@@ -72,67 +72,67 @@
                               (html-response (create-user-overview-get (get-all-course-iterations-for-user (:course-iteration-service services) user-github-id)))))
 
   (GET "/question-set/:id"
-    req
-    (question-set-get req (:question-set-service services)))
+       req
+       (question-set-get req (:question-set-service services)))
 
   (GET "/question/:id"
-    req
-    (question-get req "/question/:id/answer" (:question-service services)))
+       req
+       (question-get req "/question/:id/answer" (:question-service services)))
 
   (POST "/question/:id/answer"
-    req
-    (submit-user-answer! req (:answer-service services)))
+        req
+        (submit-user-answer! req (:answer-service services)))
 
-  ;(GET "/create-question" req
-  ;     (create-question-get req (partial get-question-categories (:question-service services)) "/create-question"))
+  ;; (GET "/create-question" req
+  ;;     (create-question-get req (partial get-question-categories (:question-service services)) "/create-question"))
 
-  ;(POST "/create-question" req
-  ;      (submit-create-question! req "/create-question" (:question-service services)))
+  ;; (POST "/create-question" req
+  ;;      (submit-create-question! req "/create-question" (:question-service services)))
 
   (GET "/create-question" req
-    (create-question-get
-     req
-     (partial get-question-categories (:question-service services))
-     (partial get-all-courses (:course-service services))  ;; NEU: Kurse holen
-     "/create-question"))
+       (create-question-get
+         req
+         (partial get-question-categories (:question-service services))
+         (partial get-all-courses (:course-service services))  ; NEU: Kurse holen
+         "/create-question"))
 
   (POST "/create-question" req
-    (submit-create-question!
-     req
-     "/create-question"
-     (:question-service services)))
+        (submit-create-question!
+          req
+          "/create-question"
+          (:question-service services)))
 
 
 
   ;; show all quetions on "http://localhost:8081/questions"
   (GET "/questions" req
-    (let [db db/create-database
-          questions (db/get-all-question-ids db)
-          courses (db/get-all-courses db)
-          course-map (reduce (fn [m course]
-                               (assoc m (:course/id course) (:course/name course)))
-                             {} courses)]
-      (html-response (questions-overview/questions-overview questions course-map)))) 
+       (let [db db/create-database
+             questions (db/get-all-question-ids db)
+             courses (db/get-all-courses db)
+             course-map (reduce (fn [m course]
+                                  (assoc m (:course/id course) (:course/name course)))
+                                {} courses)]
+         (html-response (questions-overview/questions-overview questions course-map))))
 
 
   (GET "/create-course" req
-    (create-course-get req "/create-course"))
+       (create-course-get req "/create-course"))
 
   (POST "/create-course" req
-    (submit-create-course! req "/create-course" (:course-service services)))
+        (submit-create-course! req "/create-course" (:course-service services)))
 
   (GET "/create-course-iteration" req
-    (create-course-iteration-get req "/create-course-iteration"
-                                 (partial get-all-courses (:course-service services))
-                                 (partial get-all-question-sets (:question-set-service services))))
+       (create-course-iteration-get req "/create-course-iteration"
+                                    (partial get-all-courses (:course-service services))
+                                    (partial get-all-question-sets (:question-set-service services))))
   (POST "/create-course-iteration" req
-    (submit-create-course-iteration! req "/create-course-iteration"
-                                     (partial get-all-courses (:course-service services))
-                                     (partial get-all-question-sets (:question-set-service services))
-                                     (:course-iteration-service services)))
+        (submit-create-course-iteration! req "/create-course-iteration"
+                                         (partial get-all-courses (:course-service services))
+                                         (partial get-all-question-sets (:question-set-service services))
+                                         (:course-iteration-service services)))
 
   (GET "/correction-overview" req
-    (html-response (correction-overview-get req (services :correction-service))))
+       (html-response (correction-overview-get req (services :correction-service))))
 
   (GET "/new-correction" req (html-response (new-correction-get req "/new-correction" (partial db/get-answer-by-id db) (partial db/get-question-by-id db))))
   (POST "/new-correction" req (submit-new-correction! req "/new-correction" (partial db/add-correction! db) (partial db/get-user-by-id db)))

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -1,12 +1,11 @@
 (ns db
   (:require
-   [clojure.string :as string]
-   [clojure.walk]
-   [datahike.api :as d]
-   [db.dummy-data :as dummy-data]
-   [db.schema]
-   [nano-id.core :refer [nano-id]]))
-
+    [clojure.string :as string]
+    [clojure.walk]
+    [datahike.api :as d]
+    [db.dummy-data :as dummy-data]
+    [db.schema]
+    [nano-id.core :refer [nano-id]]))
 
 
 (defprotocol Database-Protocol
@@ -145,7 +144,7 @@
 
 
 (deftype Database
-         [conn]
+  [conn]
 
   Database-Protocol
 
@@ -164,12 +163,12 @@
   (get-all-course-iterations
     [this]
     (->>
-     (d/q '[:find (pull ?e pattern)
-            :in $ pattern
-            :where [?e :course-iteration/id]]
-          @(.conn this) db.schema/course-iteration-very-slim-pull)
-     (mapv first)
-     (resolve-enums)))
+      (d/q '[:find (pull ?e pattern)
+             :in $ pattern
+             :where [?e :course-iteration/id]]
+           @(.conn this) db.schema/course-iteration-very-slim-pull)
+      (mapv first)
+      (resolve-enums)))
 
 
   (get-graded-answers-of-question-set
@@ -248,13 +247,13 @@
   (get-all-question-ids
     [this]
     (->>
-     (d/q '[:find (pull ?e pattern)
-            :in $ pattern
-            :where
-            [?e :question/id]]
-          @(.conn this) db.schema/question-slim-pull)
-     (mapv first)
-     (resolve-enums)))
+      (d/q '[:find (pull ?e pattern)
+             :in $ pattern
+             :where
+             [?e :question/id]]
+           @(.conn this) db.schema/question-slim-pull)
+      (mapv first)
+      (resolve-enums)))
 
 
   (get-all-question-categories
@@ -342,7 +341,7 @@
                                   :question/max-points (:question/max-points question)
                                   :question/statement (:question/statement question)
                                   :question/categories (:question/categories question)
-                                  :question/course [:course/id course-id]}  ;; NEU
+                                  :question/course [:course/id course-id]}  ; NEU
                            (case type
                              :question.type/free-text
                              [:question/evaluation-criteria (:question/evaluation-criteria question)]
@@ -381,18 +380,18 @@
            (resolve-enums))))
 
 
-;(get-question-ids-for-course
-;  [this course-id]
-;  (->> (d/q '[:find (pull ?q [:question/id])
-;            :in $ ?course-id
-;            :where
-;            [?q :question/course ?c]
-;            [?c :course/id ?course-id]]
-;          @(.conn this) course-id)
-;       (mapv first)
-;       (resolve-enums)))
+  ;; (get-question-ids-for-course
+  ;;  [this course-id]
+  ;;  (->> (d/q '[:find (pull ?q [:question/id])
+  ;;            :in $ ?course-id
+  ;;            :where
+  ;;            [?q :question/course ?c]
+  ;;            [?c :course/id ?course-id]]
+  ;;          @(.conn this) course-id)
+  ;;       (mapv first)
+  ;;       (resolve-enums)))
 
-  
+
   (add-user-answer!
     [this user-id question-id answer-or-solution-ids]
     (let [id (generate-id @(.conn this) :answer/id)
@@ -523,14 +522,14 @@
   (get-all-corrections-from-corrector
     [this corrector-id]
     (->>
-     (d/q '[:find (pull ?correction pattern) ?timestamp
-            :in $ pattern ?corrector-id
-            :where
-            [?correction :correction/corrector ?corrector-id ?tx]
-            [?tx :db/txInstant ?timestamp]]
-          @(.conn this) db.schema/correction-pull [:user/id corrector-id])
-     (mapv (fn [[correction timestamp]] (merge correction {:correction/timestamp timestamp})))
-     (resolve-enums)))
+      (d/q '[:find (pull ?correction pattern) ?timestamp
+             :in $ pattern ?corrector-id
+             :where
+             [?correction :correction/corrector ?corrector-id ?tx]
+             [?tx :db/txInstant ?timestamp]]
+           @(.conn this) db.schema/correction-pull [:user/id corrector-id])
+      (mapv (fn [[correction timestamp]] (merge correction {:correction/timestamp timestamp})))
+      (resolve-enums)))
 
 
   (get-answer-by-id

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -320,8 +320,8 @@
                                   :where [?q :question/course ?course-ref]]
                                 @(.conn this) [:course/id course-id])
 
-          existing-questions (map #(select-keys (first %) [:question/type :question/statement :question/max-points])
-                                  course-questions)
+          _existing-questions (map #(select-keys (first %) [:question/type :question/statement :question/max-points])
+                                   course-questions)
 
           possible-solutions (->> (question :question/possible-solutions)
                                   (mapv (fn [sol]

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -341,7 +341,7 @@
                                   :question/max-points (:question/max-points question)
                                   :question/statement (:question/statement question)
                                   :question/categories (:question/categories question)
-                                  :question/course [:course/id course-id]}  ; NEU
+                                  :question/course [:course/id course-id]}
                            (case type
                              :question.type/free-text
                              [:question/evaluation-criteria (:question/evaluation-criteria question)]

--- a/src/clj/db/schema.clj
+++ b/src/clj/db/schema.clj
@@ -91,7 +91,9 @@
   [:question/id
    {:question/type question-type-pull}
    :question/statement
-   :question/max-points])
+   :question/max-points
+   {:question/course [:course/id]}])
+
 
 
 (def question-pull
@@ -136,7 +138,11 @@
    #:db{:ident :question/categories
         :valueType :db.type/string
         :cardinality :db.cardinality/many
-        :doc "Categories/Tags for this question"}])
+        :doc "Categories/Tags for this question"}
+   #:db{:ident :question/course
+        :valueType :db.type/ref
+        :cardinality :db.cardinality/one
+        :doc "The course that owns this question"}])
 
 
 (def answer-slim-pull
@@ -271,11 +277,19 @@
    ])
 
 
+;(def course-pull
+;  [:course/id
+;   :course/name
+;   {:course/questions question-pull}
+;   {:course/question-sets question-set-pull}])
+
+
 (def course-pull
   [:course/id
    :course/name
-   {:course/questions question-pull}
+   {:course/questions question-slim-pull} 
    {:course/question-sets question-set-pull}])
+
 
 
 (def course-schema
@@ -292,11 +306,18 @@
    #:db{:ident :course/questions
         :valueType :db.type/ref
         :cardinality :db.cardinality/many
-        :doc "All questions owned by this course"}
+        :isComponent true  
+        :doc "All questions owned by this course"} 
    #:db{:ident :course/question-sets
         :valueType :db.type/ref
         :cardinality :db.cardinality/many
         :doc "All question sets owned by this course, consisting out of questions owned by this course"}])
+
+;#:db{:ident :course/questions
+;     :valueType :db.type/ref
+;     :cardinality :db.cardinality/many
+;     :doc "All questions owned by this course"}
+
 
 
 (def semester-pull ident-pull)

--- a/src/clj/db/schema.clj
+++ b/src/clj/db/schema.clj
@@ -95,7 +95,6 @@
    {:question/course [:course/id]}])
 
 
-
 (def question-pull
   (conj question-slim-pull
         :question/evaluation-criteria
@@ -277,19 +276,18 @@
    ])
 
 
-;(def course-pull
-;  [:course/id
-;   :course/name
-;   {:course/questions question-pull}
-;   {:course/question-sets question-set-pull}])
+;; (def course-pull
+;;  [:course/id
+;;   :course/name
+;;   {:course/questions question-pull}
+;;   {:course/question-sets question-set-pull}])
 
 
 (def course-pull
   [:course/id
    :course/name
-   {:course/questions question-slim-pull} 
+   {:course/questions question-slim-pull}
    {:course/question-sets question-set-pull}])
-
 
 
 (def course-schema
@@ -306,17 +304,18 @@
    #:db{:ident :course/questions
         :valueType :db.type/ref
         :cardinality :db.cardinality/many
-        :isComponent true  
-        :doc "All questions owned by this course"} 
+        :isComponent true
+        :doc "All questions owned by this course"}
    #:db{:ident :course/question-sets
         :valueType :db.type/ref
         :cardinality :db.cardinality/many
         :doc "All question sets owned by this course, consisting out of questions owned by this course"}])
 
-;#:db{:ident :course/questions
-;     :valueType :db.type/ref
-;     :cardinality :db.cardinality/many
-;     :doc "All questions owned by this course"}
+
+;; #:db{:ident :course/questions
+;;     :valueType :db.type/ref
+;;     :cardinality :db.cardinality/many
+;;     :doc "All questions owned by this course"}
 
 
 

--- a/src/clj/services/question_service/p_question_service.clj
+++ b/src/clj/services/question_service/p_question_service.clj
@@ -12,7 +12,7 @@
     "Checks if a user is assgined to a certain question.")
 
   (create-question!
-    [self question]
+    [self course-id question]
     "Creates a question entry in the database and returns a question map.")
 
   (get-question-categories

--- a/src/clj/services/question_service/question_service.clj
+++ b/src/clj/services/question_service/question_service.clj
@@ -60,8 +60,8 @@
 
 
 (defn- create-question-impl!
-  [this question]
-  (db/add-question! (.db this) question))
+  [this course-id question]
+  (db/add-question! (.db this) course-id question))
 
 
 (s/fdef get-question-categories

--- a/src/clj/services/question_set_service/question_set_service.clj
+++ b/src/clj/services/question_set_service/question_set_service.clj
@@ -12,11 +12,11 @@
   [db])
 
 
-(defn- get-course-id-from-iteration
-  [db course-iteration-id]
-  (-> (db/get-course-iteration-by-id db course-iteration-id)
-      :course-iteration/course
-      :course/id))
+;; (defn- get-course-id-from-iteration
+;;  [db course-iteration-id]
+;;  (-> (db/get-course-iteration-by-id db course-iteration-id)
+;;      :course-iteration/course
+;;      :course/id))
 
 
 (s/fdef get-all-question-sets

--- a/src/clj/services/question_set_service/question_set_service.clj
+++ b/src/clj/services/question_set_service/question_set_service.clj
@@ -12,6 +12,13 @@
   [db])
 
 
+(defn- get-course-id-from-iteration
+  [db course-iteration-id]
+  (-> (db/get-course-iteration-by-id db course-iteration-id)
+      :course-iteration/course
+      :course/id))
+
+
 (s/fdef get-all-question-sets
         :args (s/cat :self #(satisfies? PQuestionSetService %))
         :ret (s/coll-of (s/keys :req [:question-set/id])))

--- a/src/clj/views/question/create_question_view.clj
+++ b/src/clj/views/question/create_question_view.clj
@@ -101,7 +101,7 @@
    `:question-data`: Takes a map with form data keys mapped to values.
    When present, the values are put into the input fields corresponding to the name.
    This way the form can be re-/prepopulated."
-  [categories post-destination & {:keys [errors question-data course-id courses]:or {errors {} question-data {} courses []}}]
+  [categories post-destination & {:keys [errors question-data course-id courses] :or {errors {} question-data {} courses []}}]
   (let [question-types (->> question-types
                             (map name)
                             (sort))
@@ -118,99 +118,94 @@
       [:div.container
        [:h2 "Create question"]
        (hform/form-to
-        [:post post-destination]
+         [:post post-destination]
 
-        (when course-id
-          (hform/hidden-field "course-id" course-id))
-
-        
-
-        [:div
-         (hform/label {:class "form-label"} "statement" "Question statement")
-         (optional-error-display :statement errors)
-         (hform/text-area {:class "form-control" :required true} "statement" (get question-data :statement))]
-        
-
-        [:div
-         (hform/label {:class "form-label"} "course-id" "Course")
-         (optional-error-display :course-id errors)
-         (if (seq courses)
-           (hform/drop-down {:class "form-select" :required true}
-                            "course-id"
-                            (map (juxt :course/name :course/id) courses)
-                            course-id)
-           [:p "No courses available. Please create a course first."])]
-
-        [:div
-         (hform/label {:class "form-label"} "max-points" "Maximum number of points")
-         (optional-error-display :max-points errors)
-         [:input {:id "max-points"
-                  :class "form-control"
-                  :name "max-points"
-                  :type "number"
-                  :min "0"
-                  :step "1"
-                  :required true
-                  :value (get question-data :max-points 1)}]]
-
-        [:div
-         (hform/label {:class "form-label"} "type" "Question type")
-         (optional-error-display :type errors)
-         (let [selected-type (get question-data :type (first question-types))
-               type-names {"free-text" "Free text"
-                           "single-choice" "Single choice"
-                           "multiple-choice" "Multiple choice"}
-               options (->> question-types (map (juxt type-names identity)))]
-           (hform/drop-down {:class "form-select" :required true} "type" options selected-type))]
-
-        (single-choice-inputs errors question-data)
-        (multiple-choice-inputs errors question-data)
-        (free-text-inputs errors question-data)
-        (script "expert_parakeet.question.create_question_view.register_question_type_switch('type', " question-types-js-arr ");")
-        
-
-        [:div
-         [:fieldset
-          [:legend {:class "form-label"} "Categories"]
-          (optional-error-display :categories errors)
-          (let [prev-categories (set (as-coll (get question-data :categories)))
-                all-categories (set (concat categories prev-categories))]
-            [:div#category-container.ps-1 {:style "max-height: 150px; overflow-y: scroll"}
-             ;; keep this in sync with the cljs function!
-             (->> all-categories
-                  (sort)
-                  (map-indexed (fn [idx cat]
-                                 (let [id (str "category-" idx)]
-                                   [:div.form-check
-                                    (hform/check-box {:class "form-check-input"
-                                                      :name "categories"}
-                                                     id
-                                                     (contains? prev-categories cat)
-                                                     cat)
-                                    [:input {:class "form-check-input"
-                                             :id id
-                                             :type "checkbox"
-                                             :name "categories"
-                                             :value cat
-                                             :checked (contains? prev-categories cat)}]
-                                    [:label {:class "form-check-label" :for id} cat]]))))])
-          [:div.input-group
-           (hform/text-field {:class "form-control" :form "new-category-form" :required true :placeholder "Create new category"} "new-category")
-           (hform/submit-button {:class "btn btn-outline-secondary" :form "new-category-form"} "+")]]]
-
-        
-        
+         (when course-id
+           (hform/hidden-field "course-id" course-id))
 
 
-        [:div.d-flex.align-items-center.gap-2.mt-4
-         (h/raw (anti-forgery-field))
-         (hform/submit-button {:class "btn btn-primary"} "Submit")
-         [:a.btn.btn-secondary {:href "/questions"} "show questions"]]
-        
-        
-        
-        
-        )])))
+
+         [:div
+          (hform/label {:class "form-label"} "statement" "Question statement")
+          (optional-error-display :statement errors)
+          (hform/text-area {:class "form-control" :required true} "statement" (get question-data :statement))]
+
+
+         [:div
+          (hform/label {:class "form-label"} "course-id" "Course")
+          (optional-error-display :course-id errors)
+          (if (seq courses)
+            (hform/drop-down {:class "form-select" :required true}
+                             "course-id"
+                             (map (juxt :course/name :course/id) courses)
+                             course-id)
+            [:p "No courses available. Please create a course first."])]
+
+         [:div
+          (hform/label {:class "form-label"} "max-points" "Maximum number of points")
+          (optional-error-display :max-points errors)
+          [:input {:id "max-points"
+                   :class "form-control"
+                   :name "max-points"
+                   :type "number"
+                   :min "0"
+                   :step "1"
+                   :required true
+                   :value (get question-data :max-points 1)}]]
+
+         [:div
+          (hform/label {:class "form-label"} "type" "Question type")
+          (optional-error-display :type errors)
+          (let [selected-type (get question-data :type (first question-types))
+                type-names {"free-text" "Free text"
+                            "single-choice" "Single choice"
+                            "multiple-choice" "Multiple choice"}
+                options (->> question-types (map (juxt type-names identity)))]
+            (hform/drop-down {:class "form-select" :required true} "type" options selected-type))]
+
+         (single-choice-inputs errors question-data)
+         (multiple-choice-inputs errors question-data)
+         (free-text-inputs errors question-data)
+         (script "expert_parakeet.question.create_question_view.register_question_type_switch('type', " question-types-js-arr ");")
+
+
+         [:div
+          [:fieldset
+           [:legend {:class "form-label"} "Categories"]
+           (optional-error-display :categories errors)
+           (let [prev-categories (set (as-coll (get question-data :categories)))
+                 all-categories (set (concat categories prev-categories))]
+             [:div#category-container.ps-1 {:style "max-height: 150px; overflow-y: scroll"}
+              ;; keep this in sync with the cljs function!
+              (->> all-categories
+                   (sort)
+                   (map-indexed (fn [idx cat]
+                                  (let [id (str "category-" idx)]
+                                    [:div.form-check
+                                     (hform/check-box {:class "form-check-input"
+                                                       :name "categories"}
+                                                      id
+                                                      (contains? prev-categories cat)
+                                                      cat)
+                                     [:input {:class "form-check-input"
+                                              :id id
+                                              :type "checkbox"
+                                              :name "categories"
+                                              :value cat
+                                              :checked (contains? prev-categories cat)}]
+                                     [:label {:class "form-check-label" :for id} cat]]))))])
+           [:div.input-group
+            (hform/text-field {:class "form-control" :form "new-category-form" :required true :placeholder "Create new category"} "new-category")
+            (hform/submit-button {:class "btn btn-outline-secondary" :form "new-category-form"} "+")]]]
+
+
+
+
+
+         [:div.d-flex.align-items-center.gap-2.mt-4
+          (h/raw (anti-forgery-field))
+          (hform/submit-button {:class "btn btn-primary"} "Submit")
+          [:a.btn.btn-secondary {:href "/questions"} "show questions"]])])))
 
 
 (defn- possible-solutions-view

--- a/src/clj/views/question/create_question_view.clj
+++ b/src/clj/views/question/create_question_view.clj
@@ -123,6 +123,14 @@
         (when course-id
           (hform/hidden-field "course-id" course-id))
 
+        
+
+        [:div
+         (hform/label {:class "form-label"} "statement" "Question statement")
+         (optional-error-display :statement errors)
+         (hform/text-area {:class "form-control" :required true} "statement" (get question-data :statement))]
+        
+
         [:div
          (hform/label {:class "form-label"} "course-id" "Course")
          (optional-error-display :course-id errors)
@@ -132,12 +140,7 @@
                             (map (juxt :course/name :course/id) courses)
                             course-id)
            [:p "No courses available. Please create a course first."])]
-        
-        [:div
-         (hform/label {:class "form-label"} "statement" "Question statement")
-         (optional-error-display :statement errors)
-         (hform/text-area {:class "form-control" :required true} "statement" (get question-data :statement))]
-        
+
         [:div
          (hform/label {:class "form-label"} "max-points" "Maximum number of points")
          (optional-error-display :max-points errors)
@@ -164,9 +167,7 @@
         (multiple-choice-inputs errors question-data)
         (free-text-inputs errors question-data)
         (script "expert_parakeet.question.create_question_view.register_question_type_switch('type', " question-types-js-arr ");")
-
-
-
+        
 
         [:div
          [:fieldset
@@ -197,8 +198,19 @@
            (hform/text-field {:class "form-control" :form "new-category-form" :required true :placeholder "Create new category"} "new-category")
            (hform/submit-button {:class "btn btn-outline-secondary" :form "new-category-form"} "+")]]]
 
-        (h/raw (anti-forgery-field))
-        (hform/submit-button {:class "btn btn-primary"} "Submit"))])))
+        
+        
+
+
+        [:div.d-flex.align-items-center.gap-2.mt-4
+         (h/raw (anti-forgery-field))
+         (hform/submit-button {:class "btn btn-primary"} "Submit")
+         [:a.btn.btn-secondary {:href "/questions"} "show questions"]]
+        
+        
+        
+        
+        )])))
 
 
 (defn- possible-solutions-view

--- a/src/clj/views/question/create_question_view.clj
+++ b/src/clj/views/question/create_question_view.clj
@@ -247,7 +247,7 @@
             });
           });
           ")
-         (hform/submit-button {:class "btn btn-primary" :id "main-submit-btn"} "Submit")
+          (hform/submit-button {:class "btn btn-primary" :id "main-submit-btn"} "Submit")
           [:a.btn.btn-secondary {:href "/questions"} "show questions"]])])))
 
 

--- a/src/clj/views/question/question_view.clj
+++ b/src/clj/views/question/question_view.clj
@@ -1,7 +1,7 @@
 (ns views.question.question-view
   (:require
     [hiccup.form :as form]
-    [hiccup2.core :as h]
+    [hiccup2.core :as h] 
     [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
 
@@ -45,12 +45,14 @@
 (defn question-form
   [question post-destination]
   (h/html
-    (form/form-to
-      [:post post-destination]
-      [:p (:question/statement question)]
-      (dispatch-question-type question)
-      (h/raw (anti-forgery-field))
-      (form/submit-button {:class "btn btn-primary"} "Submit"))))
+   (form/form-to
+    [:post post-destination]
+    ;(when-let [course-id (:question/course question)]
+    ;  (form/hidden-field "course-id" course-id))
+    [:p (:question/statement question)]
+    (dispatch-question-type question)
+    (h/raw (anti-forgery-field))
+    (form/submit-button {:class "btn btn-primary"} "Submit"))))
 
 
 (defn no-question-assignment

--- a/src/clj/views/question/question_view.clj
+++ b/src/clj/views/question/question_view.clj
@@ -1,7 +1,7 @@
 (ns views.question.question-view
   (:require
     [hiccup.form :as form]
-    [hiccup2.core :as h] 
+    [hiccup2.core :as h]
     [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
 
@@ -45,14 +45,14 @@
 (defn question-form
   [question post-destination]
   (h/html
-   (form/form-to
-    [:post post-destination]
-    ;(when-let [course-id (:question/course question)]
-    ;  (form/hidden-field "course-id" course-id))
-    [:p (:question/statement question)]
-    (dispatch-question-type question)
-    (h/raw (anti-forgery-field))
-    (form/submit-button {:class "btn btn-primary"} "Submit"))))
+    (form/form-to
+      [:post post-destination]
+      ;; (when-let [course-id (:question/course question)]
+      ;;  (form/hidden-field "course-id" course-id))
+      [:p (:question/statement question)]
+      (dispatch-question-type question)
+      (h/raw (anti-forgery-field))
+      (form/submit-button {:class "btn btn-primary"} "Submit"))))
 
 
 (defn no-question-assignment

--- a/src/clj/views/question/questions_overview_view.clj
+++ b/src/clj/views/question/questions_overview_view.clj
@@ -1,6 +1,8 @@
 (ns views.question.questions-overview-view
-  (:require [hiccup2.core :as h]
-            [util.hiccup-extensions :refer [optional-error-display]]))
+  (:require
+    [hiccup2.core :as h]
+    [util.hiccup-extensions :refer [optional-error-display]]))
+
 
 (defn questions-overview
   [questions course-map]
@@ -23,6 +25,6 @@
             [:td (:question/statement q)]
             [:td course-name]
             [:td
-             [:a.btn.btn-sm.btn-outline-primary 
-               {:href (str "/question/" (:question/id q))} 
-               "show"]]]))]]]))
+             [:a.btn.btn-sm.btn-outline-primary
+              {:href (str "/question/" (:question/id q))}
+              "show"]]]))]]]))

--- a/src/clj/views/question/questions_overview_view.clj
+++ b/src/clj/views/question/questions_overview_view.clj
@@ -1,7 +1,6 @@
 (ns views.question.questions-overview-view
   (:require
-    [hiccup2.core :as h]
-    [util.hiccup-extensions :refer [optional-error-display]]))
+    [hiccup2.core :as h]))
 
 
 (defn questions-overview

--- a/src/clj/views/question/questions_overview_view.clj
+++ b/src/clj/views/question/questions_overview_view.clj
@@ -1,0 +1,28 @@
+(ns views.question.questions-overview-view
+  (:require [hiccup2.core :as h]
+            [util.hiccup-extensions :refer [optional-error-display]]))
+
+(defn questions-overview
+  [questions course-map]
+  (h/html
+    [:div.container
+     [:h1 "Questions"]
+     [:table.table.table-striped
+      [:thead
+       [:tr
+        [:th "ID"]
+        [:th "Statement"]
+        [:th "Course"]
+        [:th "Action"]]]
+      [:tbody
+       (for [q questions]
+         (let [course-id (-> q :question/course :course/id)
+               course-name (get course-map course-id "Unknown Course")]
+           [:tr
+            [:td (:question/id q)]
+            [:td (:question/statement q)]
+            [:td course-name]
+            [:td
+             [:a.btn.btn-sm.btn-outline-primary 
+               {:href (str "/question/" (:question/id q))} 
+               "show"]]]))]]]))

--- a/test/controllers/question/question_controller_test.clj
+++ b/test/controllers/question/question_controller_test.clj
@@ -13,7 +13,7 @@
 (deftest test-create-question-get
   (let [empty-request {}
         get-categories-fun (fn [] [])
-        get-courses-fun (fn [])]
+        get-courses-fun (fn [] [])]
     (testing "Returns a form object on normal invocation."
       (let [post-destination "post-destination"
             res (create-question-get empty-request
@@ -29,7 +29,17 @@
                                      (fn [] categories)
                                      get-courses-fun
                                      "post-destination")]
-        (t/is (every? #(string/includes? res %) categories))))))
+        (t/is (every? #(string/includes? res %) categories))))
+
+
+    (testing "All courses are displayed."
+      (let [courses [{:course/id "c1" :course/name "Math"}
+                     {:course/id "c2" :course/name "Physics"}]
+            res (create-question-get empty-request
+                                     get-categories-fun
+                                     (fn [] courses)
+                                     "post-destination")]
+        (t/is (every? #(string/includes? res (:course/name %)) courses))))))
 
 
 (defn- stub-question-service

--- a/test/controllers/question/question_controller_test.clj
+++ b/test/controllers/question/question_controller_test.clj
@@ -40,8 +40,8 @@
 
   (reify PQuestionService
     (create-question!
-     [_self course-id question]  
-     (create-question! course-id question))
+      [_self course-id question]
+      (create-question! course-id question))
 
     (get-question-categories
       [_self]

--- a/test/controllers/question/question_controller_test.clj
+++ b/test/controllers/question/question_controller_test.clj
@@ -73,7 +73,7 @@
                                                                :correct-multiple-choice-solutions ["Solution1" "Solution2"]})]
         (t/are [question-form-data]
                (let [was-called (atom false)
-                     db-add-fun-stub (fn [_ course-id question]
+                     db-add-fun-stub (fn [_course-id question]
                                        (reset! was-called true)
                                        (-> question
                                            (update :question/possible-solutions (fn [sols]
@@ -117,7 +117,7 @@
                                                                :correct-multiple-choice-solutions ["Solution1" "Unknown solution"]})]
         (t/are [question-form-data]
                (let [was-not-called (atom true)
-                     db-add-fun-stub (fn [_ course-id question]
+                     db-add-fun-stub (fn [_course-id question]
                                        (reset! was-not-called false)
                                        (-> question
                                            (update :question/possible-solution (fn [sols]

--- a/test/controllers/question/question_controller_test.clj
+++ b/test/controllers/question/question_controller_test.clj
@@ -40,8 +40,8 @@
 
   (reify PQuestionService
     (create-question!
-      [_self question]
-      (create-question! question))
+     [_self course-id question]  
+     (create-question! course-id question))
 
     (get-question-categories
       [_self]
@@ -56,11 +56,12 @@
   (let [db-stub (reify Database-Protocol)]
     (testing "Test that the db-add-function gets called with valid parameters."
       (let [test-request {:__anti-forgery-token ""
-                          :params {}}
+                          :params {:course-id "test-course-id"}}
             question-service (->QuestionService db-stub)
             basic-valid-input {:statement "Valid question statement"
                                :categories ["Valid Category"]
-                               :max-points "5"}
+                               :max-points "5"
+                               :course-id "test-course-id"}
             post-destination "S"
             free-text-question (merge basic-valid-input {:type "free-text"
                                                          :evaluation-criteria "Valid evaluation criteria"})
@@ -72,7 +73,7 @@
                                                                :correct-multiple-choice-solutions ["Solution1" "Solution2"]})]
         (t/are [question-form-data]
                (let [was-called (atom false)
-                     db-add-fun-stub (fn [question]
+                     db-add-fun-stub (fn [_ course-id question]
                                        (reset! was-called true)
                                        (-> question
                                            (update :question/possible-solutions (fn [sols]
@@ -98,11 +99,12 @@
 
     (testing "Test that the db-add-function is not called with invalid parameters"
       (let [test-request {:__anti-forgery-token ""
-                          :params {}}
+                          :params {:course-id "test-course-id"}}
             question-service (->QuestionService db-stub)
             basic-valid-input {:statement "Valid question statement"
                                :categories ["Valid Category"]
-                               :max-points "5"}
+                               :max-points "5"
+                               :course-id "test-course-id"}
             post-destination "S"
             single-choice-question1 (merge basic-valid-input {:type "single-choice"
                                                               :possible-single-choice-solutions ["Solution1" "Solution2" "Solution3"]
@@ -115,7 +117,7 @@
                                                                :correct-multiple-choice-solutions ["Solution1" "Unknown solution"]})]
         (t/are [question-form-data]
                (let [was-not-called (atom true)
-                     db-add-fun-stub (fn [question]
+                     db-add-fun-stub (fn [_ course-id question]
                                        (reset! was-not-called false)
                                        (-> question
                                            (update :question/possible-solution (fn [sols]

--- a/test/controllers/question/question_controller_test.clj
+++ b/test/controllers/question/question_controller_test.clj
@@ -12,11 +12,13 @@
 
 (deftest test-create-question-get
   (let [empty-request {}
-        get-categories-fun (fn [] [])]
+        get-categories-fun (fn [] [])
+        get-courses-fun (fn [])]
     (testing "Returns a form object on normal invocation."
       (let [post-destination "post-destination"
             res (create-question-get empty-request
                                      get-categories-fun
+                                     get-courses-fun
                                      post-destination)]
         (t/is (and (string/includes? res "form")
                    (string/includes? res post-destination)))))
@@ -25,6 +27,7 @@
       (let [categories ["Cat1" "Cat2" "Hello World ok!"]
             res (create-question-get empty-request
                                      (fn [] categories)
+                                     get-courses-fun
                                      "post-destination")]
         (t/is (every? #(string/includes? res %) categories))))))
 

--- a/test/controllers/xss_test.clj
+++ b/test/controllers/xss_test.clj
@@ -115,7 +115,7 @@
                                                :max-points (:question/max-points q-text)
                                                :categories (:question/categories q-text)}}}]
       (t/are [html-output] (not (string/includes? html-output xss-payload))
-        (create-question-get req get-question-categories-fun post-destination)
+        (create-question-get req get-question-categories-fun post-destination (:question-service services))
         (submit-create-question! req-submit post-destination (:question-service services))))))
 
 

--- a/test/controllers/xss_test.clj
+++ b/test/controllers/xss_test.clj
@@ -120,7 +120,6 @@
         (submit-create-question! req-submit post-destination (:question-service services))))))
 
 
-
 (deftest test-create-course
   (testing "Create course html-code should be escaped to prevent XSS."
     (let [req-submit {:params {:course-data {:name xss-payload}}}]

--- a/test/controllers/xss_test.clj
+++ b/test/controllers/xss_test.clj
@@ -108,7 +108,8 @@
 
 (deftest test-create-question
   (testing "Create question html-code should be escaped to prevent XSS."
-    (let [req-submit {:params {:question-data {:id (:question/id q-text)
+    (let [req-submit {:params {:course-id "test-course-id"
+                               :question-data {:id (:question/id q-text)
                                                :type (:question/type q-text)
                                                :statement (:question/statement q-text)
                                                :evaluation-criteria (:question/evaluation-criteria q-text)
@@ -117,6 +118,7 @@
       (t/are [html-output] (not (string/includes? html-output xss-payload))
         (create-question-get req get-question-categories-fun post-destination (:question-service services))
         (submit-create-question! req-submit post-destination (:question-service services))))))
+
 
 
 (deftest test-create-course

--- a/test/db_test.clj
+++ b/test/db_test.clj
@@ -53,7 +53,7 @@
                             :question/correct-solutions ["42"]
                             :question/max-points 1
                             :question/categories ["Cat1"]}
-            _ (db/add-question! test-db input-question)
+            _ (db/add-question! test-db "1" input-question)
             question-ids (map :question/id (db/get-all-question-ids test-db))
             question-list (map #(db/get-question-by-id test-db %) question-ids)]
         (t/is (some #(= % (input-question :question/statement)) (map :question/statement question-list)))))
@@ -64,7 +64,7 @@
                             :question/correct-solutions ["42" "Alien"]
                             :question/max-points 1
                             :question/categories ["Cat2"]}
-            _ (db/add-question! test-db input-question)
+            _ (db/add-question! test-db "1" input-question)
             question-ids (map #(:question/id %) (db/get-all-question-ids test-db))
             question-list (map #(db/get-question-by-id test-db %) question-ids)]
         (t/is (some #(= % (input-question :question/statement)) (map :question/statement question-list)))))
@@ -74,7 +74,7 @@
                             :question/evaluation-criteria "Never gonna give you up"
                             :question/max-points 2
                             :question/categories ["Cat2" "Cat3"]}
-            _ (db/add-question! test-db input-question)
+            _ (db/add-question! test-db "1" input-question)
             question-ids (map #(:question/id %) (db/get-all-question-ids test-db))
             question-list (map #(db/get-question-by-id test-db %) question-ids)]
         (t/is (some #(= % (input-question :question/statement)) (map :question/statement question-list)))))
@@ -85,15 +85,15 @@
                             :question/correct-solutions ["42"]
                             :question/max-points 1
                             :question/categories ["Cat1"]}]
-        (t/is (thrown? java.lang.IllegalArgumentException (db/add-question! test-db input-question)))))
+        (t/is (thrown? java.lang.IllegalArgumentException (db/add-question! test-db "1" input-question)))))
     (testing "add-question! with already existing free-text-choice question as input: duplicate questions are now allowed"
       (let [input-question {:question/type :question.type/free-text
                             :question/statement "What are some advantages and disadvantages of example-based and generative testing?"
                             :question/evaluation-criteria "The following aspects are explained: Oracle, performance, test-coverage"
                             :question/max-points 2
                             :question/categories #{"Cat1" "Cat3"}}
-            _ (db/add-question! test-db input-question)
-            _ (db/add-question! test-db input-question)
+            _ (db/add-question! test-db "1" input-question)
+            _ (db/add-question! test-db "1" input-question)
             question-ids (map #(:question/id %) (db/get-all-question-ids test-db))
             question-list (map #(db/get-question-by-id test-db %) question-ids)
             matching-questions (filter #(= (:question/statement %) (:question/statement input-question)) question-list)]

--- a/test/services/question_service/question_service_test.clj
+++ b/test/services/question_service/question_service_test.clj
@@ -105,7 +105,8 @@
     (let [was-called (atom false)
           db-stub (reify Database-Protocol
                     (add-question!
-                      [_this course-id _question]
+                      [_this _question]
+                      ;; course-id
                       (swap! was-called (fn [_] true))
                       {}))
           question-service (->QuestionService db-stub)]

--- a/test/services/question_service/question_service_test.clj
+++ b/test/services/question_service/question_service_test.clj
@@ -105,9 +105,9 @@
     (let [was-called (atom false)
           db-stub (reify Database-Protocol
                     (add-question!
-                      [_this _question]
+                      [_this course-id _question]
                       (swap! was-called (fn [_] true))
                       {}))
           question-service (->QuestionService db-stub)]
-      (create-question! question-service {})
+      (create-question! question-service "1" {})
       (t/is @was-called))))

--- a/test/services/question_service/question_service_test.clj
+++ b/test/services/question_service/question_service_test.clj
@@ -105,7 +105,7 @@
     (let [was-called (atom false)
           db-stub (reify Database-Protocol
                     (add-question!
-                      [_this _question]
+                      [_this _course-id _question]
                       ;; course-id
                       (swap! was-called (fn [_] true))
                       {}))

--- a/test/view/question/create_question_view_test.clj
+++ b/test/view/question/create_question_view_test.clj
@@ -61,7 +61,8 @@
     (let [categories ["Cat1" "Cat2"]
           post-destination "https://some.url"
           possible-solutions ["Solution1" "Solution2" "More solutions"]
-          basic-input {:statement "Valid question statement."
+          basic-input {;; :question/id "q-2"
+                       :statement "Valid question statement."
                        :categories [(first categories)]
                        :max-points "5"
                        :evaluation-criteria "Some evaluation criteria"

--- a/test/view/question/question_view_test.clj
+++ b/test/view/question/question_view_test.clj
@@ -7,13 +7,16 @@
 
 (deftest test-question-form-dispatch
   (testing "Test that a text-area is shown in the view, when the question is a free text question."
-    (let [question {:question/type :question.type/free-text
+    (let [question {:question/id "q-1"
+                    :question/type :question.type/free-text
                     :question/statement "Why 42?"}
           dispatched-form (question-form question "https://some.url")]
       (t/is (string/includes? dispatched-form "textarea"))))
 
   (testing "Test that checkboxes are shown in the view, when the question is a multiple-choice question."
-    (let [question {:question/type :question.type/multiple-choice
+    (let [question {:question/id "q-2"
+                    ;; :question/course "Functional Programming: Clojure"
+                    :question/type :question.type/multiple-choice
                     :question/statement "Why 42?"
                     :question/possible-solutions [{:solution/id "1" :solution/statement "A"}
                                                   {:solution/id "2" :solution/statement "B"}
@@ -22,7 +25,9 @@
       (t/is (string/includes? dispatched-form "checkbox"))))
 
   (testing "Test that radio-buttons are shown in the view, when the question is a single-choice question."
-    (let [question {:question/type :question.type/single-choice
+    (let [question {:question/id "q-3"
+                    ;; :question/course "Functional Programming: Clojure"
+                    :question/type :question.type/single-choice
                     :question/statement "Why 42?"
                     :question/possible-solutions [{:solution/id "1" :solution/statement "A"}
                                                   {:solution/id "2" :solution/statement "B"}

--- a/test/view/question/question_view_test.clj
+++ b/test/view/question/question_view_test.clj
@@ -15,7 +15,7 @@
 
   (testing "Test that checkboxes are shown in the view, when the question is a multiple-choice question."
     (let [question {:question/id "q-2"
-                    ;; :question/course "Functional Programming: Clojure"
+                    :question/course "Test-Course"
                     :question/type :question.type/multiple-choice
                     :question/statement "Why 42?"
                     :question/possible-solutions [{:solution/id "1" :solution/statement "A"}
@@ -26,7 +26,7 @@
 
   (testing "Test that radio-buttons are shown in the view, when the question is a single-choice question."
     (let [question {:question/id "q-3"
-                    ;; :question/course "Functional Programming: Clojure"
+                    :question/course "Test-Course"
                     :question/type :question.type/single-choice
                     :question/statement "Why 42?"
                     :question/possible-solutions [{:solution/id "1" :solution/statement "A"}

--- a/test/view/xss_test.clj
+++ b/test/view/xss_test.clj
@@ -15,6 +15,7 @@
 
 (def xss-question
   {:question/type :question.type/free-text
+   :question/course "c1"
    :question/statement xss-data
    :question/max-points 10
    :question/categories [xss-data]})


### PR DESCRIPTION
# Purpose
This PR adds the option to assign a course when creating a question. This helps keep questions linked to the right courses.

# Key changes
* Updated the question creation form to include a dropdown for selecting a course.  
* If no course is chosen in the form, it falls back to the course from the session or route.  
* Modified the database schema: questions now reference a course (`:question/course`), and courses keep track of their questions (`:course/questions`).  
* Adjusted the `create-question!` function to require a `course-id`.  
* Added a new `/questions` page that lists all questions along with their associated course names.
