### PR TITLE
feat: add user course iteration registrations

### DIFF
--- a/src/clj/controllers/course_iteration/course_iteration_controller.clj
+++ b/src/clj/controllers/course_iteration/course_iteration_controller.clj
@@ -6,7 +6,7 @@
     [services.course-iteration-service.p-course-iteration-service :refer [create-course-iteration PCourseIterationService
                                                                           validate-course-iteration]]
     [util.ring-extensions :refer [html-response]]
-    [views.course-iteration.create-course-iteration-view :as view]))
+    [views.course-iteration.create-course-iteration-view :as creation-view]))
 
 
 (s/fdef create-course-iteration-get
@@ -35,8 +35,8 @@
   (let [courses (get-courses-fun)
         question-sets (get-question-sets-fun)]
     (if (empty? courses)
-      (html-response (view/no-courses))
-      (html-response (view/course-iteration-form courses question-sets post-destination)))))
+      (html-response (creation-view/no-courses))
+      (html-response (creation-view/course-iteration-form courses question-sets post-destination)))))
 
 
 (s/fdef submit-create-course-iteration!
@@ -59,7 +59,7 @@
         validation-errors (course-iteration-or-errors :errors)]
     (if (empty? validation-errors)
       (let [added-course-iteration (create-course-iteration course-iteration-service course-iteration-or-errors)]
-        (html-response (view/submit-success-view added-course-iteration)))
+        (html-response (creation-view/submit-success-view added-course-iteration)))
       (let [courses (get-courses-fun)
             question-sets (get-question-sets-fun)]
-        (html-response (view/course-iteration-form courses question-sets post-destination :errors validation-errors :course-iteration-data form-data))))))
+        (html-response (creation-view/course-iteration-form courses question-sets post-destination :errors validation-errors :course-iteration-data form-data))))))

--- a/src/clj/controllers/course_iteration/registration_controller.clj
+++ b/src/clj/controllers/course_iteration/registration_controller.clj
@@ -1,0 +1,26 @@
+(ns controllers.course-iteration.registration-controller
+  (:require
+    [ring.util.response :refer [redirect]]
+    [services.course-iteration-service.p-course-iteration-service :refer [create-course-iteration-registration]]
+    [util.ring-extensions :refer [html-response]]
+    [views.course-iteration.registration-view :as view]))
+
+
+(defn create-registration-get
+  [req post-destination get-course-iterations-fun]
+  (html-response
+    (view/registration-get post-destination
+                           (str (-> req :session :user :id))
+                           (get-course-iterations-fun))))
+
+
+(defn submit-create-registration
+  [req redirect-url course-iteration-service]
+  (let [form-data (-> req :params (dissoc :__anti-forgery-token))
+        user-id (str (-> req :session :user :id))
+        course-iteration-id (:course-iteration-id form-data)]
+    (create-course-iteration-registration
+      course-iteration-service
+      course-iteration-id
+      user-id)
+    (redirect redirect-url)))

--- a/src/clj/core.clj
+++ b/src/clj/core.clj
@@ -8,6 +8,7 @@
     [controllers.correction.correction-controller :refer [correction-overview-get]]
     [controllers.correction.new-correction-controller :refer [new-correction-get submit-new-correction!]]
     [controllers.course-iteration.course-iteration-controller :refer [create-course-iteration-get submit-create-course-iteration!]]
+    [controllers.course-iteration.registration-controller :refer [create-registration-get submit-create-registration]]
     [controllers.course.course-controller :refer [create-course-get submit-create-course!]]
     [controllers.question-set.question-set-controller :refer [question-set-get]]
     [controllers.question.question-controller :refer [create-question-get
@@ -25,7 +26,7 @@
     [services.answer-service.answer-service :refer [->AnswerService]]
     [services.correction-service.correction-service :refer [->CorrectionService]]
     [services.course-iteration-service.course-iteration-service :refer [->CourseIterationService]]
-    [services.course-iteration-service.p-course-iteration-service :refer [get-all-course-iterations-for-user]]
+    [services.course-iteration-service.p-course-iteration-service :refer [get-all-course-iterations get-all-course-iterations-for-user]]
     [services.course-service.course-service :refer [->CourseService]]
     [services.course-service.p-course-service :refer [get-all-courses]]
     [services.question-service.p-question-service :refer [get-question-categories]]
@@ -103,12 +104,17 @@
                                          (partial get-all-courses (:course-service services))
                                          (partial get-all-question-sets (:question-set-service services))
                                          (:course-iteration-service services)))
+  (GET "/registration" req (create-registration-get req "/registration"
+                                                    (partial get-all-course-iterations (:course-iteration-service services))))
+  (POST "/registration" req (submit-create-registration req "/registration" (:course-iteration-service services)))
 
   (GET "/correction-overview" req
        (html-response (correction-overview-get req (services :correction-service))))
 
   (GET "/new-correction" req (html-response (new-correction-get req "/new-correction" (partial db/get-answer-by-id db) (partial db/get-question-by-id db))))
   (POST "/new-correction" req (submit-new-correction! req "/new-correction" (partial db/add-correction! db) (partial db/get-user-by-id db)))
+
+
 
   (route/not-found "Not Found"))
 

--- a/src/clj/db.clj
+++ b/src/clj/db.clj
@@ -54,6 +54,9 @@
   (add-course-iteration!
     [this course])
 
+  (add-course-iteration-registration!
+    [this course-iteration-id user-id])
+
   (get-question-by-id
     [this id])
 
@@ -166,7 +169,7 @@
       (d/q '[:find (pull ?e pattern)
              :in $ pattern
              :where [?e :course-iteration/id]]
-           @(.conn this) db.schema/course-iteration-very-slim-pull)
+           @(.conn this) db.schema/course-iteration-pull)
       (mapv first)
       (resolve-enums)))
 
@@ -302,6 +305,15 @@
           db-after (:db-after tx-result)]
       (->> (d/pull db-after db.schema/course-iteration-slim-pull [:course-iteration/id id])
            (resolve-enums))))
+
+
+  (add-course-iteration-registration!
+    [this course-iteration-id user-id]
+    (let [tx-result (d/transact (.conn this)
+                                [[:db/add [:course-iteration/id course-iteration-id]
+                                  :course-iteration/registrations [:user/id user-id]]])
+          db-after (:db-after tx-result)]
+      (->> (d/pull db-after db.schema/course-iteration-pull [:course-iteration/id course-iteration-id]))))
 
 
   (get-question-by-id

--- a/src/clj/db/schema.clj
+++ b/src/clj/db/schema.clj
@@ -311,7 +311,7 @@
    {:course-iteration/course course-slim-pull}
    :course-iteration/year
    {:course-iteration/semester semester-pull}
-   ;; no members and no question sets
+   ;; no members, no registrations and no question sets
    ])
 
 
@@ -320,7 +320,7 @@
    {:course-iteration/course course-slim-pull}
    :course-iteration/year
    {:course-iteration/semester semester-pull}
-   ;; no members
+   ;; no members and no registrations
    {:course-iteration/question-sets question-set-no-questions-pull}])
 
 
@@ -330,6 +330,7 @@
    :course-iteration/year
    {:course-iteration/semester semester-pull}
    {:course-iteration/members membership-pull}
+   {:course-iteration/registrations user-pull}
    {:course-iteration/question-sets question-set-slim-pull}])
 
 
@@ -356,6 +357,10 @@
         :valueType :db.type/ref
         :cardinality :db.cardinality/many
         :doc "The members (as membership references) of this course iteration"}
+   #:db{:ident :course-iteration/registrations
+        :valueType :db.type/ref
+        :cardinality :db.cardinality/many
+        :doc "The users who want to register for this course iteration"}
    #:db{:ident :course-iteration/question-sets
         :cardinality :db.cardinality/many
         :valueType :db.type/ref

--- a/src/clj/services/course_iteration_service/course_iteration_service.clj
+++ b/src/clj/services/course_iteration_service/course_iteration_service.clj
@@ -74,8 +74,26 @@
       (partial db/get-graded-answers-of-question-set (.db this) user-id))))
 
 
+(s/fdef create-course-iteration-registration-impl
+        :args (s/cat :self #(satisfies? PCourseIterationService %)
+                     :course-iteration-id :course-iteration/id
+                     :user-id :user/id))
+
+
+(defn- create-course-iteration-registration-impl
+  [this course-iteration-id user-id]
+  (db/add-course-iteration-registration! (.db this) course-iteration-id user-id))
+
+
+(defn- get-all-course-iterations
+  [this]
+  (db/get-all-course-iterations (.db this)))
+
+
 (extend CourseIterationService
   PCourseIterationService
   {:create-course-iteration create-course-iteration-impl
    :validate-course-iteration (partial validate-form-data course-iteration-validators)
-   :get-all-course-iterations-for-user get-all-course-iterations-for-user})
+   :get-all-course-iterations get-all-course-iterations
+   :get-all-course-iterations-for-user get-all-course-iterations-for-user
+   :create-course-iteration-registration create-course-iteration-registration-impl})

--- a/src/clj/services/course_iteration_service/p_course_iteration_service.clj
+++ b/src/clj/services/course_iteration_service/p_course_iteration_service.clj
@@ -11,6 +11,14 @@
     [self course-iteration-form-data]
     "Validates the values for the creation of a course-iteration. Returns a map of error keys or the validated course iteration.")
 
+  (get-all-course-iterations
+    [self]
+    "Returns a collection of all available course iterations.")
+
   (get-all-course-iterations-for-user
     [self user-github-id]
-    "Returns a collection of all available course iterations for a student."))
+    "Returns a collection of all available course iterations for a student.")
+
+  (create-course-iteration-registration
+    [self course-iteration-id user-id]
+    "Register a user for a particular course iteration"))

--- a/src/clj/views/course_iteration/registration_view.clj
+++ b/src/clj/views/course_iteration/registration_view.clj
@@ -1,0 +1,41 @@
+(ns views.course-iteration.registration-view
+  (:require
+    [hiccup.form :as hform]
+    [hiccup2.core :as h]
+    [ring.util.anti-forgery :refer [anti-forgery-field]]))
+
+
+(defn- semester-diplay
+  [semester]
+  (case semester
+    :semester/summer "Summer"
+    :semester/winter "Winter"))
+
+
+(defn- is-user-registered
+  [user-id course-iteration]
+  (some #(= (:user/id %) user-id) (:course-iteration/registrations course-iteration)))
+
+
+(defn registration-get
+  "Returns an html form, used to register for iterations of a course.
+   Iterations the user has already registered for are greyed out"
+  [post-destination user-id all-course-iterations]
+  (h/html
+    [:div
+     [:ul {:class "list-group"}
+      (for [c all-course-iterations]
+        [:li {:class "list-group-item d-flex align-items-center justify-content-between"}
+         [:div {:class "row"}
+          [:span {:class "fs-4"} (-> c :course-iteration/course :course/name)]
+          [:span {:class "fs-6 text-secondary"}
+           (-> c :course-iteration/semester semester-diplay)
+           " "
+           (-> c :course-iteration/year str)]]
+         (hform/form-to
+           [:post post-destination]
+           (h/raw (anti-forgery-field))
+           (hform/hidden-field "course-iteration-id" (-> c :course-iteration/id))
+           (if (not (is-user-registered user-id c))
+             (hform/submit-button {:class "btn btn-primary"} "Register")
+             (hform/submit-button {:class "btn btn-primary disabled"} "Registered")))])]]))

--- a/test/controllers/course_iteration/course_iteration_controller_test.clj
+++ b/test/controllers/course_iteration/course_iteration_controller_test.clj
@@ -22,9 +22,10 @@
 
 
 (defn- stub-course-iteration-service
-  [& {:keys [validate-course-iteration create-course-iteration]
+  [& {:keys [validate-course-iteration create-course-iteration create-course-iteration-registration]
       :or {validate-course-iteration (fn [& _] {})
-           create-course-iteration (fn [& _] {})}}]
+           create-course-iteration (fn [& _] {})
+           create-course-iteration-registration (fn [& _] {})}}]
   (reify PCourseIterationService
     (validate-course-iteration
       [_self course-iteration-form-data]
@@ -32,7 +33,11 @@
 
     (create-course-iteration
       [_self course-iteration]
-      (create-course-iteration course-iteration))))
+      (create-course-iteration course-iteration))
+
+    (create-course-iteration-registration
+      [_self course-iteration-id user-id]
+      (create-course-iteration-registration course-iteration-id user-id))))
 
 
 (deftest test-submit-create-course-iteration!

--- a/test/db_test.clj
+++ b/test/db_test.clj
@@ -251,7 +251,28 @@
       (t/is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #"Nothing found for entity id [:course-iteration/id \W 42\W ]"
-              (db/get-course-iteration-by-id test-db "42"))))))
+              (db/get-course-iteration-by-id test-db "42"))))
+    (testing "add-course-iteration-registration! basic insertion"
+      (let [course-iteration-id "1"
+            user-id "1"
+            result (db/add-course-iteration-registration! test-db course-iteration-id user-id)]
+        (t/is (some #(= user-id (:user/id %)) (:course-iteration/registrations result)))))
+    (testing "add-course-iteration-registration! with invalid user id"
+      (let [course-iteration-id "1"
+            user-id "invalid"]
+        (t/is (thrown-with-msg?
+                clojure.lang.ExceptionInfo
+                #"Nothing found for entity id [:user/id \W invalid \W]"
+                (db/add-course-iteration-registration!
+                  test-db course-iteration-id user-id)))))
+    (testing "add-course-iteration-registration! with invalid course-iteration id"
+      (let [course-iteration-id "invalid"
+            user-id "1"]
+        (t/is (thrown-with-msg?
+                clojure.lang.ExceptionInfo
+                #"Nothing found for entity id [:course-iteration/id \W invalid \W]"
+                (db/add-course-iteration-registration!
+                  test-db course-iteration-id user-id)))))))
 
 
 (deftest question-set-tests

--- a/test/services/course_iteration_service/course_iteration_service_test.clj
+++ b/test/services/course_iteration_service/course_iteration_service_test.clj
@@ -1,0 +1,25 @@
+(ns services.course-iteration-service.course-iteration-service-test
+  (:require
+    [clojure.test :as t :refer [deftest testing]]
+    [db :refer [Database-Protocol]]
+    [services.course-iteration-service.course-iteration-service :refer [->CourseIterationService]]
+    [services.course-iteration-service.p-course-iteration-service :refer [create-course-iteration-registration]]))
+
+
+(deftest test-create-course-iteration-registration
+  (testing "CourseIterationService implementation calls database query"
+    (let [was-called (atom false)
+          user-id-param "1"
+          course-iteration-id-param "1"
+          db-stub (reify Database-Protocol
+                    (add-course-iteration-registration!
+                      [_this course-iteration-id user-id]
+                      (swap! was-called (constantly true))
+                      (t/is (= user-id user-id-param))
+                      (t/is (= course-iteration-id course-iteration-id-param))
+                      {}))
+          course-iteration-service (->CourseIterationService db-stub)]
+      (create-course-iteration-registration course-iteration-service
+                                            course-iteration-id-param
+                                            user-id-param)
+      (t/is @was-called))))

--- a/test/view/course_iteration/registration_view_test.clj
+++ b/test/view/course_iteration/registration_view_test.clj
@@ -1,0 +1,48 @@
+(ns view.course-iteration.registration-view-test
+  (:require
+    [clojure.string :as string]
+    [clojure.test :as t :refer [deftest testing]]
+    [views.course-iteration.registration-view :refer [registration-get]]))
+
+
+(deftest registration-get-test
+  (testing "Testing that the registration get view shows every course-iteration sent to it"
+    (t/are [post-destination user-id course-iterations]
+           (let [test-result (str (registration-get post-destination user-id course-iterations))
+                 already-registered-courses (filter (fn [c]
+                                                      (some
+                                                        #(= (:user/id %) user-id)
+                                                        (:course-iteration/registrations c)))
+                                                    course-iterations)]
+             (and
+               (every? #(string/includes? test-result (-> % :course-iteration/course :course/name)) course-iterations)
+               (= (count already-registered-courses) (count (re-seq #"disabled" test-result)))
+               (if (not-empty course-iterations)
+                 (string/includes? test-result post-destination)
+                 true)))
+
+      "http://localhost:1337/postme"
+      "666"
+      [#:course-iteration{:id "999"
+                          :course {:course/name "Funktionale Programmierung 3"}
+                          :registrations []
+                          :semester :semester/winter
+                          :year 2025}
+       #:course-iteration{:id "1000"
+                          :course {:course/name "Funktionale Programmierung 4"}
+                          :registrations []
+                          :semester :semester/summer
+                          :year 1970}]
+
+      "http://localhost:1337/postme"
+      "666"
+      [#:course-iteration{:id "999"
+                          :course {:course/name "Funktionale Programmierung 3"}
+                          :registrations [{:user/id "666"} {:user/id "invalid"}]
+                          :semester :semester/winter
+                          :year 2025}
+       #:course-iteration{:id "1000"
+                          :course {:course/name "Funktionale Programmierung 4"}
+                          :registrations []
+                          :semester :semester/summer
+                          :year 1970}])))


### PR DESCRIPTION
Added the concept of registration to course-iterations. The name `course-iteration-registration` is a bit clunky, but its the most precise thing i could come up with.

Also added a `/registration` view where users can register for available course iterations.

In combination with #196, this solves #166 

~~This PR is still missing a bit of polish, so should not be merged just yet.~~